### PR TITLE
Fix undefined reference to `std::istream::seekg(long, std::_Ios_Seekdir)'

### DIFF
--- a/jma/jma.h
+++ b/jma/jma.h
@@ -19,6 +19,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #define JMA_H
 
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <time.h>
 #include <vector>


### PR DESCRIPTION
When i tried to compile the emulator, the error in the title appeared, this fixes it 