### PR TITLE
Apply patches to support -D_FORTIFY_SOURCE=2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ CC ?= gcc
 CXX ?= g++
 
 # TODO: FreeBSD has a patch for being able to build without -fcommon
-CFLAGS += -m32 -pthread -rdynamic -no-pie -std=gnu99 -fcommon -O1 -march=pentium-mmx -fno-inline -fno-pic -mtune=generic -mmmx -D_FORTIY_SOURCE=0 -L/usr/lib32 -mno-sse -mno-sse2 -ffunction-sections -fdata-sections -Wfatal-errors -w
-CXXFLAGS += -m32 -pthread -rdynamic -no-pie -std=gnu++14 -O1 -march=pentium-mmx -fno-inline -fno-pic -mtune=generic -mmmx -D_FORTIFY_SOURCE=0 -L/usr/lib32 -mno-sse -mno-sse2 -ffunction-sections -fdata-sections -Wfatal-errors -w
+CFLAGS += -m32 -pthread -rdynamic -no-pie -std=gnu99 -fcommon -O1 -march=pentium-mmx -fno-inline -fno-pic -mtune=generic -mmmx -D_FORTIY_SOURCE=2 -L/usr/lib32 -mno-sse -mno-sse2 -ffunction-sections -fdata-sections -Wfatal-errors -w
+CXXFLAGS += -m32 -pthread -rdynamic -no-pie -std=gnu++14 -O1 -march=pentium-mmx -fno-inline -fno-pic -mtune=generic -mmmx -D_FORTIFY_SOURCE=2 -L/usr/lib32 -mno-sse -mno-sse2 -ffunction-sections -fdata-sections -Wfatal-errors -w
 LDFLAGS += -Wl,--as-needed -no-pie -ldl -lX11 -L/usr/lib32 -Wl,--gc-sections -lz
 # -O1 is mandatory
 ASMFLAGS += -O1 -w-orphan-labels

--- a/gblvars.h
+++ b/gblvars.h
@@ -35,8 +35,8 @@ extern uint32_t SPCMultA, PHnum2writespc7110reg, PHdspsave2;
 extern uint32_t* setaramdata;
 extern uint8_t *romdata, *SA1RAMArea;
 
-extern unsigned char sndrot, SPCRAM[65472], DSPMem[256], SA1Status;
-extern unsigned char DSP1Enable, DSP1COp, prevoamptr, BRRBuffer[32];
+extern unsigned char sndrot, SPCRAM[], DSPMem[256], SA1Status;
+extern unsigned char DSP1Enable, DSP1COp, prevoamptr, BRRBuffer[];
 extern unsigned char curcyc, spcnumread, NextLineCache, HIRQNextExe;
 extern unsigned char vidmemch8[4096], vidmemch2[4096];
 

--- a/initc.c
+++ b/initc.c
@@ -1363,7 +1363,7 @@ void clearmem(void)
     clearmem2();
 }
 
-extern uint8_t BRRBuffer[32];
+extern uint8_t BRRBuffer[];
 extern uint8_t echoon0;
 extern uint32_t PHdspsave;
 extern uint32_t PHdspsave2;

--- a/zstate.c
+++ b/zstate.c
@@ -118,7 +118,7 @@ static void copy_spc_data(uint8_t** buffer, void (*copy_func)(uint8_t**, void*, 
 {
     // SPC stuff, DSP stuff
     copy_func(buffer, SPCRAM, PHspcsave);
-    copy_func(buffer, &BRRBuffer, PHdspsave);
+    copy_func(buffer, BRRBuffer, PHdspsave);
     copy_func(buffer, &DSPMem, sizeof(DSPMem));
 }
 


### PR DESCRIPTION
* Initial bug report: https://github.com/xyproto/zsnes/issues/5
* Arch Linux bug report: https://bugs.archlinux.org/task/75031#comment208938
* Patches from rpmfusion/zsnes https://github.com/rpmfusion/zsnes

zsnes now builds and runs with `-D_FORTIFY_SOURCE=2` without crashing at start.