### PR TITLE
[Testing needed] Fix issues with games that store to 420C twice.

### DIFF
--- a/cpu/c_dma.c
+++ b/cpu/c_dma.c
@@ -215,13 +215,16 @@ void c_reg420Cw(u4 eax)
 {
     u1 const al = eax;
     curhdma = al;
-    if (curypos < resolutn && (!(INTEnab & 0x10) || (80 <= HIRQLoc && HIRQLoc <= 176)) && nexthdma & al == 0) {
+    // [sneed] fix games that use double HDMA.
+    if (curypos < resolutn && (!(INTEnab & 0x10) || (80 <= HIRQLoc && HIRQLoc <= 176))) {
         nexthdma = al;
-        DMAInfo* esi = dmadata;
-        HDMAInfo* edx = hdmadata;
-        for (u1 i = 0x01; i != 0; ++esi, ++edx, i <<= 1) {
-            if (al & i)
-                setuphdma(i, edx, esi);
+        if (al != 0x00) {
+            DMAInfo* esi = dmadata;
+            HDMAInfo* edx = hdmadata;
+            for (u1 i = 0x01; i != 0; ++esi, ++edx, i <<= 1) {
+                if (al & i)
+                    setuphdma(i, edx, esi);
+            }
         }
     }
     if (nohdmaframe == 1)


### PR DESCRIPTION
Solves #18 - Weird behaviour with multiple 420C writes not emulated properly. Fixes Yoshi's Island, Makes Star Fox and Star Fox 2 start, but they will freeze during the title screen unless per2exec is set to 50 in zsnesl.cfg.

Needs testing to make sure it doesn't break other games, but most games I've tested don't rely on this at all, only writing to 420C once on V-Blank. This only affected games that used IRQ to shrink down the screen resolution and needed to start HDMA processing on a scanline other than 0, so mostly Super FX games.