### PR TITLE
Added support for 8MB SA-1/SDD-1 roms

### DIFF
--- a/chips/c_sa1regs.c
+++ b/chips/c_sa1regs.c
@@ -35,7 +35,6 @@ void SA1Reset(void)
     irqv = irqv2;
     nmiv = nmiv2;
     SA1RegPCS = romdata - 0x8000;
-    SA1RAMArea = romdata + 4096 * 1024;
     u1* const eax = romdata + 4096 * 1024 - 0x6000;
     CurBWPtr = eax;
     SA1BWPtr = eax;

--- a/chips/c_sa1regs.c
+++ b/chips/c_sa1regs.c
@@ -35,10 +35,9 @@ void SA1Reset(void)
     irqv = irqv2;
     nmiv = nmiv2;
     SA1RegPCS = romdata - 0x8000;
-    u1* const eax = romdata + 4096 * 1024 - 0x6000;
-    CurBWPtr = eax;
-    SA1BWPtr = eax;
-    SNSBWPtr = eax;
+    CurBWPtr = SA1RAMArea - 0x6000;
+    SA1BWPtr = SA1RAMArea - 0x6000;
+    SNSBWPtr = SA1RAMArea - 0x6000;
     SA1xa = 0;
     SA1xx = 0;
     SA1xy = 0;

--- a/chips/sa1regs.asm
+++ b/chips/sa1regs.asm
@@ -501,8 +501,8 @@ NEWSYM sa12224w ; BWRAM
     mov bl,al
     and ebx,1Fh
     shl ebx,13
-    add ebx,[romdata]
-    add ebx,1024*4096-6000h
+    add ebx,[SA1RAMArea]
+    sub ebx,6000h
     mov [SNSBWPtr],ebx
     cmp byte[SA1Status],0
     jne .nosnes
@@ -516,8 +516,8 @@ NEWSYM sa12225w ; BWRAM
     mov bl,al
     and ebx,1Fh
     shl ebx,13
-    add ebx,[romdata]
-    add ebx,1024*4096-6000h
+    add ebx,[SA1RAMArea]
+    sub ebx,6000h
     mov [SA1BWPtr],ebx
     cmp byte[SA1Status],0
     je .nosa1b
@@ -547,8 +547,7 @@ NEWSYM sa12225w ; BWRAM
     and ebx,3Fh
     shl ebx,12
 .4col
-    add ebx,[romdata]
-    add ebx,1024*4096
+    add ebx,[SA1RAMArea]
     mov [SA1BWPtr],ebx
     cmp byte[SA1Status],0
     je .nosa1
@@ -936,7 +935,7 @@ sa1chconv:
     pushad
     mov edx,[sa1dmaptrs]
     mov ebx,[romdata]
-    add ebx,4096*1024+1024*1024
+    add ebx,0xE00000 ; [sneed] Fix SA-1
     mov edi,16*2
 .loop38b
     push ebx
@@ -979,7 +978,7 @@ sa1chconv:
     mov ecx,10000h
     mov edx,[sa1dmaptrs]
     mov ebx,[romdata]
-    add ebx,4096*1024+1024*1024
+    add ebx,0xE00000 ; [sneed] Fix SA-1
 .next8b
     mov al,[ebx]
     mov [edx],al
@@ -994,7 +993,7 @@ sa1chconv:
     pushad
     mov edx,[sa1dmaptrs]
     mov ebx,[romdata]
-    add ebx,4096*1024+1024*1024
+    add ebx,0xE00000 ; [sneed] Fix SA-1
     mov edi,16
 .loop34b
     push ebx
@@ -1031,7 +1030,7 @@ sa1chconv:
     mov ecx,10*128*8
     mov edx,[sa1dmaptrs]
     mov ebx,[romdata]
-    add ebx,4096*1024+1024*1024
+    add ebx,0xE00000 ; [sneed] Fix SA-1
 .next4b
     mov al,[ebx]
     mov [edx],al
@@ -1047,7 +1046,7 @@ sa1chconv:
     pushad
     mov edx,[sa1dmaptrs]
     mov ebx,[romdata]
-    add ebx,4096*1024+1024*1024
+    add ebx,0xE00000 ; [sneed] Fix SA-1
     mov edi,16
 .loop3
     push ebx
@@ -1081,7 +1080,7 @@ sa1chconv:
     mov ecx,10*64*8
     mov edx,[sa1dmaptrs]
     mov ebx,[romdata]
-    add ebx,4096*1024+1024*1024
+    add ebx,0xE00000 ; [sneed] Fix SA-1
 .next
     mov al,[ebx]
     mov [edx],al

--- a/cpu/s65816d.inc
+++ b/cpu/s65816d.inc
@@ -822,6 +822,8 @@ COPemulmode
     mov esi,IRAM
     sub esi,3000h
     mov [initaddrl],esi
+    and eax,7ffh
+    add eax,3000h		;FuSoYa:Fixes the fix
     add esi,eax
     endloop
 %endmacro

--- a/ui.c
+++ b/ui.c
@@ -41,6 +41,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #define BIT(x) (1 << (x))
 
+extern uint8_t *SA1RAMArea;
 extern unsigned int xa, maxromspace;
 extern unsigned char spcon, device1, device2;
 extern char CSStatus[], CSStatus2[], CSStatus3[], CSStatus4[];
@@ -272,22 +273,12 @@ static void allocmem()
     AllocmemFail(vcache2b, 262144 + 256);
     AllocmemFail(vcache4b, 131072 + 256);
     AllocmemFail(vcache8b, 65536 + 256);
+    AllocmemFail(SA1RAMArea, 131072);
+    AllocmemFail(romaptr, 0x1000000);
 
     newgfx16b = 1;
-    if ((romaptr = malloc(0x600000 + 32768 * 2 + 4096))) {
-        maxromspace = 0x600000;
-    } else {
-        if ((romaptr = malloc(0x400000 + 32768 * 2 + 4096))) {
-            maxromspace = 0x400000;
-        } else {
-            if ((romaptr = malloc(0x200000 + 32768 * 2 + 4096))) {
-                maxromspace = 0x200000;
-            } else {
-                outofmemory();
-            }
-        }
-    }
-
+    maxromspace = 0xC00000;
+    
     // Set up memory values
     vidbuffer = vbufaptr;
     vidbufferofsa = vbufaptr;
@@ -296,8 +287,8 @@ static void allocmem()
 
     headdata = romaptr;
     romdata = romaptr;
-    sfxramdata = romaptr + 0x400000;
-    setaramdata = romaptr + 0x400000;
+    sfxramdata = romaptr + 0xE00000;
+    setaramdata = romaptr + 0xE00000;
 
     // Puts this ASM after the end of the ROM:
     //         CLI

--- a/zstate.c
+++ b/zstate.c
@@ -600,7 +600,6 @@ void RestoreSA1()
     }
 
     SA1Ptr += (uintptr_t)SA1RegPCS;
-    SA1RAMArea = romdata + 4096 * 1024;
 }
 
 #define ResState(Voice_BufPtr)                               \


### PR DESCRIPTION
Solves #17

Changes:
- Maxromspace is now 0xC00000 and no longer dynamic, the size of the ROM buffer has been bumped to 16MB from 6MB. The upper half is stored for storing special chip variables to conserve memory.
- Backports a security update where SA-1 DMA could be used to execute arbitrary code.
- Added ExLoROM mapper support