### PR TITLE
Makefile: factor out common flags, fix "FORTIY" typo in CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ ARCH := LINUX
 CC ?= gcc
 CXX ?= g++
 
+COMMON_FLAGS = -m32 -pthread -no-pie -O1 -march=pentium-mmx -fno-inline -fno-pic -mtune=generic -mmmx -D_FORTIFY_SOURCE=2 -L/usr/lib32 -mno-sse -mno-sse2 -ffunction-sections -fdata-sections -Wfatal-errors -w
+
 # TODO: FreeBSD has a patch for being able to build without -fcommon
-CFLAGS += -m32 -pthread -no-pie -std=gnu99 -fcommon -O1 -march=pentium-mmx -fno-inline -fno-pic -mtune=generic -mmmx -D_FORTIY_SOURCE=2 -L/usr/lib32 -mno-sse -mno-sse2 -ffunction-sections -fdata-sections -Wfatal-errors -w
-CXXFLAGS += -m32 -pthread -no-pie -std=gnu++14 -O1 -march=pentium-mmx -fno-inline -fno-pic -mtune=generic -mmmx -D_FORTIFY_SOURCE=2 -L/usr/lib32 -mno-sse -mno-sse2 -ffunction-sections -fdata-sections -Wfatal-errors -w
+CFLAGS += $(COMMON_FLAGS) -std=gnu99 -fcommon
+CXXFLAGS += $(COMMON_FLAGS) -std=gnu++14
 LDFLAGS += -Wl,--as-needed -no-pie -L/usr/lib32 -Wl,--gc-sections -lz
 # -O1 is mandatory
 ASMFLAGS += -O1 -w-orphan-labels


### PR DESCRIPTION
This factors out some duplicate/tedious text in the Makefile...and fixes a typo in the CFLAGS.