### PR TITLE
Reubenhwk/fix uninitialized sound buffer

### DIFF
--- a/linux/audio.c
+++ b/linux/audio.c
@@ -301,7 +301,7 @@ static int SoundInit_sdl()
 
     sdl_audio_buffer_len = audiospec.size * 2;
     sdl_audio_buffer_len = (sdl_audio_buffer_len + 255) & ~255; // Align to SPCSize
-    if (!(sdl_audio_buffer = malloc(sdl_audio_buffer_len))) {
+    if (!(sdl_audio_buffer = calloc(1, sdl_audio_buffer_len))) {
         SDL_CloseAudio();
         puts("Audio Open Failed");
         SoundEnabled = 0;

--- a/linux/audio.c
+++ b/linux/audio.c
@@ -299,8 +299,7 @@ static int SoundInit_sdl()
     }
     SDL_PauseAudio(0);
 
-    sdl_audio_buffer_len = audiospec.size * 2;
-    sdl_audio_buffer_len = (sdl_audio_buffer_len + 255) & ~255; // Align to SPCSize
+    sdl_audio_buffer_len = (audiospec.size * 2 + 255) & ~255; // Align to SPCSize
     if (!(sdl_audio_buffer = calloc(1, sdl_audio_buffer_len))) {
         SDL_CloseAudio();
         puts("Audio Open Failed");


### PR DESCRIPTION
Zero out the sound buffer when starting sound...otherwise there is wretched clicking and popping on startup when SDL starts to play uninitialized memory.