### PR TITLE
fix sndrot/regsbackup buffer overruns

### DIFF
--- a/c_init.c
+++ b/c_init.c
@@ -80,7 +80,7 @@ void init(void)
 
     /* XXX sndrot is a global variable, but is treated like the first entry of a
      * big struct */
-    memcpy(regsbackup, &sndrot, sizeof(regsbackup));
+    memcpy(regsbackup, &sndrot, sizeof(sndrot));
 
     clearmem();
 

--- a/initc.c
+++ b/initc.c
@@ -2421,7 +2421,7 @@ void powercycle(bool sramload, bool romload)
         }
 
         sramsavedis = 0;
-        memcpy(&sndrot, regsbackup, 3019);
+        memcpy(&sndrot, regsbackup, sizeof(sndrot));
 
         if (yesoutofmemory)
             outofmemfix();

--- a/zstate.c
+++ b/zstate.c
@@ -107,7 +107,7 @@ static void copy_snes_data(uint8_t** buffer, void (*copy_func)(uint8_t**, void*,
     copy_func(buffer, &cycpbl, 4);
     copy_func(buffer, &cycpblt, 4);
     // SNES PPU Register status
-    copy_func(buffer, &sndrot, 3019);
+    copy_func(buffer, &sndrot, 1);
 }
 
 static void copy_spc_data(uint8_t** buffer, void (*copy_func)(uint8_t**, void*, size_t))


### PR DESCRIPTION
sizeof sndrot is 1.  sizeof regsbackup is 3019.  sndrot is backed up in regsbackup in just the first byte, so only copy in/out that 1 byte.

This fixes a crash which can be reproduced at some optimization levels, but not others.  For example, -O1 crashes, but -g doesn't.