### PR TITLE
fix libao sound by using correct clock

### DIFF
--- a/linux/audio.c
+++ b/linux/audio.c
@@ -150,7 +150,7 @@ static void* SoundThread_ao(void* useless)
 
         // The while() is there to prevent error codes from breaking havoc
         while (!samples_waiting) {
-            clock_gettime(CLOCK_MONOTONIC, &to);
+            clock_gettime(CLOCK_REALTIME, &to);
             to.tv_sec += 10;
             pthread_cond_timedwait(&audio_wait, &audio_mutex, &to); // Wait for signal
         }


### PR DESCRIPTION
pthread_condition_wait need to use CLOCK_REALTIME, not CLOCK_MONTOMIC. Using the wrong clock means the function never sleeps and wastes CPU cycles.  I see a reduction from 18% CPU usage to 8%.