### PR TITLE
Implement MSU-1 revision 2 resume functionality

### DIFF
--- a/chips/msu1emu.c
+++ b/chips/msu1emu.c
@@ -31,10 +31,12 @@ u1* MSU_DATA = NULL;
 // DSP
 short* TRACK_DATA = NULL;
 u2 MSU_Track;
+u2 MSU_Resume_Track = -1;
 u1 MSU_MusicVolume;
 u1 MSU_CurrentStatus;
 int MSU_Rate_Add = 0;
 int MSU_Track_Position = 0;
+int MSU_Resume_Track_Position = 0;
 int MSU_Loop_Point = 0;
 int MSU_Track_Length = 0;
 int MSU_Busy = 0;
@@ -118,7 +120,13 @@ void MSU1HandleTrackChange()
         ;
         ;
     }
-    MSU_Track_Position = 0;
+    if (MSU_Track == MSU_Resume_Track) {
+        MSU_Track_Position = MSU_Resume_Track_Position;
+        MSU_Resume_Track = -1;
+        MSU_Resume_Track_Position = 0;
+    } else {
+        MSU_Track_Position = 0;
+    }
     MSU_Rate_Add = 0;
 
     // Requested a track.
@@ -179,6 +187,12 @@ void MSU1GetStatusBitsSpecial()
 void MSU1HandleStatusBits()
 {
     MSU1GetStatusBitsSpecial();
+
+    // Check for and set up resume
+    if (MSU_CurrentStatus == 0x4) {
+        MSU_Resume_Track = MSU_Track;
+        MSU_Resume_Track_Position = MSU_Track_Position;
+    }
 
     // Error reading audio
     if (MSU_StatusRead & 0x8) {

--- a/chips/msu1emu.h
+++ b/chips/msu1emu.h
@@ -7,6 +7,7 @@
 extern u1 MSU_StatusRead;
 extern u1 MSU_MusicVolume;
 extern int MSU_Track_Position;
+extern int MSU_Resume_Track_Position;
 extern char MSU_BasePath[4096];
 int readMSU();
 


### PR DESCRIPTION
I noticed that this fork implements MSU-1 support, but while reporting a chip revision of 2, it doesn't implement the audio resume feature added in that revision. This PR should fix that.
Tested with the MSU-1 patch for [Chrono Trigger](https://www.romhacking.net/hacks/2546/) (resume version).

When register $2007 is written such that only bit 2 (resume flag) is set, the current track index and the offset into the current track are saved.
When the track registers are written to ($2004/$2005) with the index of the saved track and a track change is triggered, the track offset is set to the saved offset, and the resume position/track variables are reset.
This allows for switching to another audio track for a period and switching back to the previous track exactly where it left off.
The mentioned Chrono Trigger patch uses this functionality to resume the area music after a battle.