### PR TITLE
MSU-1 Improvements

### DIFF
--- a/chips/msu1emu.c
+++ b/chips/msu1emu.c
@@ -32,8 +32,8 @@ u1* MSU_DATA = NULL;
 short* TRACK_DATA = NULL;
 u2 MSU_Track;
 u2 MSU_Resume_Track = -1;
-u1 MSU_MusicVolume;
-u1 MSU_CurrentStatus;
+u1 MSU_AudioVolume;
+u1 MSU_StateControl;
 int MSU_Rate_Add = 0;
 int MSU_Track_Position = 0;
 int MSU_Resume_Track_Position = 0;
@@ -77,9 +77,9 @@ int readMSU()
         MSU_DATA = NULL;
     }
     MSU_Data_Seek = 0;
-    MSU_StatusRead = 2;
+    MSU_StatusRead = MSU_REVISION;
     MSU_Busy = 0;
-    MSU_MusicVolume = 0xFF;
+    MSU_AudioVolume = 0xFF;
 
     // Get Filename
     size_t len = strlen(MSU_BasePath);
@@ -120,18 +120,22 @@ void MSU1HandleTrackChange()
         ;
         ;
     }
+
+    // If requested track matches resume track, restore track position
     if (MSU_Track == MSU_Resume_Track) {
         MSU_Track_Position = MSU_Resume_Track_Position;
+        // Reset resume variables
         MSU_Resume_Track = -1;
         MSU_Resume_Track_Position = 0;
     } else {
         MSU_Track_Position = 0;
     }
+
     MSU_Rate_Add = 0;
 
     // Requested a track.
     MSU_Track_Length = 0;
-    MSU_StatusRead &= ~0x30; // Turn off playing bits
+    MSU_StatusRead &= ~(MSU_STATUS_PLAY + MSU_STATUS_LOOP); // Turn off playing bits
 
     // Request new track
 #ifdef DEBUG
@@ -177,9 +181,9 @@ void MSU1HandleTrackChange()
 // Read from bits
 void MSU1GetStatusBitsSpecial()
 {
-    MSU_StatusRead &= 0x37; // Leave revision and playing bits alone
+    MSU_StatusRead &= 0x37; // Leave revision, playing, and busy bits alone
     if (!MSU_Track_Length) {
-        MSU_StatusRead |= 0x8;
+        MSU_StatusRead |= MSU_STATUS_ERROR;
     }
 }
 
@@ -189,16 +193,16 @@ void MSU1HandleStatusBits()
     MSU1GetStatusBitsSpecial();
 
     // Check for and set up resume
-    if (MSU_CurrentStatus == 0x4) {
+    if (MSU_StateControl == MSU_CONTROL_RESUME) {
         MSU_Resume_Track = MSU_Track;
         MSU_Resume_Track_Position = MSU_Track_Position;
     }
 
     // Error reading audio
-    if (MSU_StatusRead & 0x8) {
+    if (MSU_StatusRead & MSU_STATUS_ERROR) {
         return;
     }
-    MSU_StatusRead = (MSU_StatusRead & ~0x30) | ((MSU_CurrentStatus & 0x03) << 4);
+    MSU_StatusRead = (MSU_StatusRead & ~(MSU_STATUS_PLAY + MSU_STATUS_LOOP)) | ((MSU_StateControl & (MSU_CONTROL_PLAY + MSU_CONTROL_LOOP)) << 4);
 #ifdef DEBUG
     printf("Status bits new: %hhu\n", MSU_StatusRead);
 #endif
@@ -208,18 +212,18 @@ void MSU1HandleStatusBits()
 void mixMSU1Audio(int* start, int* end, int rate)
 {
     // Play
-    if ((MSU_StatusRead & 0x10) && MSU_Track_Length > 0) {
+    if ((MSU_StatusRead & MSU_STATUS_PLAY) && MSU_Track_Length > 0) {
         MSU_Busy = 1;
-        // printf("MSU Status: Track: %d   Playing: %d     Repeat: %d    Volume: %d     Pos: %d/%d\n", (int)MSU_Track, MSU_Playing, MSU_Repeat, (int)MSU_MusicVolume, MSU_Track_Position, MSU_Track_Length);
+        // printf("MSU Status: Track: %d   Playing: %d     Repeat: %d    Volume: %d     Pos: %d/%d\n", (int)MSU_Track, MSU_Playing, MSU_Repeat, (int)MSU_AudioVolume, MSU_Track_Position, MSU_Track_Length);
         for (; start < end; start++) {
             // Check if the pointer of the track is valid.
             if (MSU_Track_Position < MSU_Track_Length) {
-                *start += (TRACK_DATA[MSU_Track_Position] * MSU_MusicVolume) / 0x80;
+                *start += (TRACK_DATA[MSU_Track_Position] * MSU_AudioVolume) / 0x80;
 
                 // Stereo Mixer
                 if (StereoSound) {
                     *start++;
-                    *start += (TRACK_DATA[MSU_Track_Position + 1] * MSU_MusicVolume) / 0x80;
+                    *start += (TRACK_DATA[MSU_Track_Position + 1] * MSU_AudioVolume) / 0x80;
                 }
 
                 // Take care of incrementing the pointer
@@ -232,7 +236,7 @@ void mixMSU1Audio(int* start, int* end, int rate)
 
             // Check if we should repeat
             if (MSU_Track_Position >= MSU_Track_Length) {
-                if (MSU_StatusRead & 0x20) {
+                if (MSU_StatusRead & MSU_STATUS_LOOP) {
                     MSU_Track_Position = MSU_Loop_Point * 2;
                 }
             }

--- a/chips/msu1emu.c
+++ b/chips/msu1emu.c
@@ -242,6 +242,9 @@ void mixMSU1Audio(int* start, int* end, int rate)
             if (MSU_Track_Position >= MSU_Track_Length) {
                 if (MSU_StatusRead & MSU_STATUS_LOOP) {
                     MSU_Track_Position = MSU_Loop_Point * 2;
+                } else {
+                    // Track finished and not looping, clear play bit
+                    MSU_StatusRead &= ~MSU_STATUS_PLAY;
                 }
             }
         }

--- a/chips/msu1emu.c
+++ b/chips/msu1emu.c
@@ -39,7 +39,6 @@ int MSU_Track_Position = 0;
 int MSU_Resume_Track_Position = 0;
 int MSU_Loop_Point = 0;
 int MSU_Track_Length = 0;
-int MSU_Busy = 0;
 char MSU_BasePath[4096];
 
 // Prepare read registers
@@ -78,7 +77,7 @@ int readMSU()
     }
     MSU_Data_Seek = 0;
     MSU_StatusRead = MSU_REVISION;
-    MSU_Busy = 0;
+    MSU_StatusRead &= ~MSU_STATUS_DATA_BUSY; // Clear data busy bit
     MSU_AudioVolume = 0xFF;
 
     // Get Filename
@@ -116,11 +115,12 @@ int readMSU()
 
 void MSU1HandleTrackChange()
 {
-    while (MSU_Busy) {
-        ;
-        ;
+    // Writes have no effect if audio busy bit set
+    if (MSU_StatusRead & MSU_STATUS_AUDIO_BUSY) {
+        return;
     }
-
+    // Begin track change, set audio busy bit
+    MSU_StatusRead |= MSU_STATUS_AUDIO_BUSY;
     // If requested track matches resume track, restore track position
     if (MSU_Track == MSU_Resume_Track) {
         MSU_Track_Position = MSU_Resume_Track_Position;
@@ -176,6 +176,8 @@ void MSU1HandleTrackChange()
             printf("Not enough space in memory for MSU-1.\n");
         }
     }
+    // Track change complete, clear audio busy bit
+    MSU_StatusRead &= ~MSU_STATUS_AUDIO_BUSY;
 }
 
 // Read from bits
@@ -213,7 +215,7 @@ void mixMSU1Audio(int* start, int* end, int rate)
 {
     // Play
     if ((MSU_StatusRead & MSU_STATUS_PLAY) && MSU_Track_Length > 0) {
-        MSU_Busy = 1;
+        MSU_StatusRead |= MSU_STATUS_AUDIO_BUSY; // Set audio busy flag
         // printf("MSU Status: Track: %d   Playing: %d     Repeat: %d    Volume: %d     Pos: %d/%d\n", (int)MSU_Track, MSU_Playing, MSU_Repeat, (int)MSU_AudioVolume, MSU_Track_Position, MSU_Track_Length);
         for (; start < end; start++) {
             // Check if the pointer of the track is valid.
@@ -241,6 +243,6 @@ void mixMSU1Audio(int* start, int* end, int rate)
                 }
             }
         }
-        MSU_Busy = 0;
+        MSU_StatusRead &= ~MSU_STATUS_AUDIO_BUSY; // Clear audio busy flag
     }
 }

--- a/chips/msu1emu.c
+++ b/chips/msu1emu.c
@@ -25,7 +25,8 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 // Data
 u1 MSU_StatusRead;
-u4 MSU_Data_Seek;
+u4 MSU_Data_SeekPort;
+u4 MSU_Data_Addr;
 u1* MSU_DATA = NULL;
 
 // DSP
@@ -75,7 +76,8 @@ int readMSU()
         free(MSU_DATA);
         MSU_DATA = NULL;
     }
-    MSU_Data_Seek = 0;
+    MSU_Data_SeekPort = 0;
+    MSU_Data_Addr = 0;
     MSU_StatusRead = MSU_REVISION;
     MSU_StatusRead &= ~MSU_STATUS_DATA_BUSY; // Clear data busy bit
     MSU_AudioVolume = 0xFF;

--- a/chips/msu1emu.c
+++ b/chips/msu1emu.c
@@ -185,7 +185,7 @@ void MSU1HandleTrackChange()
 // Read from bits
 void MSU1GetStatusBitsSpecial()
 {
-    MSU_StatusRead &= 0x37; // Leave revision, playing, and busy bits alone
+    MSU_StatusRead &= (MSU_STATUS_LOOP + MSU_STATUS_PLAY + MSU_STATUS_REVISION); // Leave revision, play/loop, and busy bits alone
     if (!MSU_Track_Length) {
         MSU_StatusRead |= MSU_STATUS_ERROR;
     }

--- a/chips/msu1emu.c
+++ b/chips/msu1emu.c
@@ -215,6 +215,12 @@ void MSU1HandleStatusBits()
 // Mix MSU1 audio signal with DSP
 void mixMSU1Audio(int* start, int* end, int rate)
 {
+    extern unsigned char EMUPause;
+    // Don't process MSU-1 audio if emulator is paused
+    if (EMUPause) {
+        return;
+    }
+
     // Play
     if ((MSU_StatusRead & MSU_STATUS_PLAY) && MSU_Track_Length > 0) {
         MSU_StatusRead |= MSU_STATUS_AUDIO_BUSY; // Set audio busy flag

--- a/chips/msu1emu.c
+++ b/chips/msu1emu.c
@@ -31,10 +31,12 @@ u1* MSU_DATA = NULL;
 // DSP
 short* TRACK_DATA = NULL;
 u2 MSU_Track;
+u2 MSU_Resume_Track = -1;
 u1 MSU_MusicVolume;
 u1 MSU_CurrentStatus;
 int MSU_Rate_Add = 0;
 int MSU_Track_Position = 0;
+int MSU_Resume_Track_Position = 0;
 int MSU_Loop_Point = 0;
 int MSU_Track_Length = 0;
 int MSU_Busy = 0;
@@ -118,7 +120,13 @@ void MSU1HandleTrackChange()
         ;
         ;
     }
-    MSU_Track_Position = 0;
+    if (MSU_Track == MSU_Resume_Track) {
+        MSU_Track_Position = MSU_Resume_Track_Position;
+        MSU_Resume_Track = -1;
+        MSU_Resume_Track_Position = 0;
+    } else {
+        MSU_Track_Position = 0;
+    }
     MSU_Rate_Add = 0;
 
     // Requested a track.
@@ -179,6 +187,12 @@ void MSU1GetStatusBitsSpecial()
 void MSU1HandleStatusBits()
 {
     MSU1GetStatusBitsSpecial();
+
+    // Check for and set up resume
+    if (MSU_CurrentStatus == 0x4) {
+        MSU_Resume_Track = MSU_Track;
+        MSU_Resume_Track_Position = MSU_Track_Position;
+    }
 
     // Error reading audio
     if (MSU_StatusRead & 0x8) {

--- a/chips/msu1emu.h
+++ b/chips/msu1emu.h
@@ -4,7 +4,7 @@
 #include "../types.h"
 
 // Bitfield Constants
-// 0x2000 (MSU_STATUS)
+// 0x2000 read (MSU_STATUS)
 #define MSU_STATUS_REVISION0 0x01
 #define MSU_STATUS_REVISION1 0x02
 #define MSU_STATUS_REVISION2 0x04
@@ -13,7 +13,7 @@
 #define MSU_STATUS_LOOP 0x20
 #define MSU_STATUS_AUDIO_BUSY 0x40
 #define MSU_STATUS_DATA_BUSY 0x80
-// 0x2007 (MSU_CONTROL)
+// 0x2007 write (MSU_CONTROL)
 #define MSU_CONTROL_PLAY 0x01
 #define MSU_CONTROL_LOOP 0x02
 #define MSU_CONTROL_RESUME 0x04

--- a/chips/msu1emu.h
+++ b/chips/msu1emu.h
@@ -3,21 +3,20 @@
 
 #include "../types.h"
 
-// Bitfield Constants
-// 0x2000 read (MSU_STATUS)
-#define MSU_STATUS_REVISION0 0x01
-#define MSU_STATUS_REVISION1 0x02
-#define MSU_STATUS_REVISION2 0x04
+// Status bits ($2000 read)
+#define MSU_STATUS_REVISION 0x07 // bits 0-2
 #define MSU_STATUS_ERROR 0x08
 #define MSU_STATUS_PLAY 0x10
 #define MSU_STATUS_LOOP 0x20
 #define MSU_STATUS_AUDIO_BUSY 0x40
 #define MSU_STATUS_DATA_BUSY 0x80
-// 0x2007 write (MSU_CONTROL)
+
+// Control bits ($2007 write)
 #define MSU_CONTROL_PLAY 0x01
 #define MSU_CONTROL_LOOP 0x02
 #define MSU_CONTROL_RESUME 0x04
-// Chip Revision
+
+// MSU-1 Revision
 #define MSU_REVISION 2
 
 // File

--- a/chips/msu1emu.h
+++ b/chips/msu1emu.h
@@ -3,9 +3,26 @@
 
 #include "../types.h"
 
+// Bitfield Constants
+// 0x2000 (MSU_STATUS)
+#define MSU_STATUS_REVISION0 0x01
+#define MSU_STATUS_REVISION1 0x02
+#define MSU_STATUS_REVISION2 0x04
+#define MSU_STATUS_ERROR 0x08
+#define MSU_STATUS_PLAY 0x10
+#define MSU_STATUS_LOOP 0x20
+#define MSU_STATUS_AUDIO_BUSY 0x40
+#define MSU_STATUS_DATA_BUSY 0x80
+// 0x2007 (MSU_CONTROL)
+#define MSU_CONTROL_PLAY 0x01
+#define MSU_CONTROL_LOOP 0x02
+#define MSU_CONTROL_RESUME 0x04
+// Chip Revision
+#define MSU_REVISION 2
+
 // File
 extern u1 MSU_StatusRead;
-extern u1 MSU_MusicVolume;
+extern u1 MSU_AudioVolume;
 extern int MSU_Track_Position;
 extern int MSU_Resume_Track_Position;
 extern char MSU_BasePath[4096];

--- a/chips/msu1emu.h
+++ b/chips/msu1emu.h
@@ -7,6 +7,7 @@
 extern u1 MSU_StatusRead;
 extern u1 MSU_MusicVolume;
 extern int MSU_Track_Position;
+extern int MSU_Resume_Track_Position;
 extern char MSU_BasePath[4096];
 int readMSU();
 

--- a/chips/msu1regs.asm
+++ b/chips/msu1regs.asm
@@ -77,7 +77,14 @@ NEWSYM msudataseek2
 	mov [MSU_Data_SeekPort+2],al
 ret
 NEWSYM msudataseek3
+	; Writing to $2003 triggers seek
 	mov [MSU_Data_SeekPort+3],al
+
+	; writes have no effect if data busy bit set
+	mov al,[MSU_StatusRead]
+	and al,80h
+	jnz .dontseek
+
 	; Start seek, set data busy bit
 	or byte[MSU_StatusRead],80h
 	; Set data address to seek port
@@ -85,6 +92,8 @@ NEWSYM msudataseek3
 	mov [MSU_Data_Addr],eax
 	; Seek finished, clear data busy bit
 	and byte[MSU_StatusRead],~80h
+
+.dontseek
 ret
 
 ;TRACK

--- a/chips/msu1regs.asm
+++ b/chips/msu1regs.asm
@@ -14,7 +14,8 @@
 ;Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 %include "macros.mac"
 
-EXTSYM MSU_StateControl,MSU_AudioVolume,MSU_Track,MSU_Data_SeekPort,MSU_Data_Addr,MSU_DATA,MSU_StatusRead,MSU1HandleTrackChange,MSU1HandleStatusBits,MSU1GetStatusBitsSpecial
+EXTSYM MSU_StateControl,MSU_AudioVolume,MSU_Track,MSU_Data_SeekPort,MSU_Data_Addr
+EXTSYM MSU_DATA,MSU_StatusRead,MSU1HandleTrackChange,MSU1HandleStatusBits,MSU1GetStatusBitsSpecial
 
 SECTION .text
 

--- a/chips/msu1regs.asm
+++ b/chips/msu1regs.asm
@@ -14,7 +14,7 @@
 ;Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 %include "macros.mac"
 
-EXTSYM MSU_StateControl,MSU_AudioVolume,MSU_Track,MSU_Data_Seek,MSU_DATA,MSU_StatusRead,MSU1HandleTrackChange,MSU1HandleStatusBits,MSU1GetStatusBitsSpecial
+EXTSYM MSU_StateControl,MSU_AudioVolume,MSU_Track,MSU_Data_SeekPort,MSU_Data_Addr,MSU_DATA,MSU_StatusRead,MSU1HandleTrackChange,MSU1HandleStatusBits,MSU1GetStatusBitsSpecial
 
 SECTION .text
 
@@ -29,11 +29,11 @@ ret
 ;DATA read
 NEWSYM msudataread
 	mov ebx,[MSU_DATA]
-	add ebx,[MSU_Data_Seek]
+	add ebx,[MSU_Data_SeekPort]
 	mov al,[ebx]
 
 	;increment seek
-	inc dword[MSU_Data_Seek]
+	inc dword[MSU_Data_SeekPort]
 ret
 
 ;MSU-1 ID
@@ -60,16 +60,23 @@ ret
 
 ;DATA Seek Pointer
 NEWSYM msudataseek0
-	mov [MSU_Data_Seek],al
+	mov [MSU_Data_SeekPort],al
 ret
 NEWSYM msudataseek1
-	mov [MSU_Data_Seek+1],al
+	mov [MSU_Data_SeekPort+1],al
 ret
 NEWSYM msudataseek2
-	mov [MSU_Data_Seek+2],al
+	mov [MSU_Data_SeekPort+2],al
 ret
 NEWSYM msudataseek3
-	mov [MSU_Data_Seek+3],al
+	mov [MSU_Data_SeekPort+3],al
+	; Start seek, set data busy bit
+	or byte[MSU_StatusRead],80h
+	; Set data address to seek port
+	mov eax,[MSU_Data_SeekPort]
+	mov [MSU_Data_Addr],eax
+	; Seek finished, clear data busy bit
+	and byte[MSU_StatusRead],~80h
 ret
 
 ;TRACK

--- a/chips/msu1regs.asm
+++ b/chips/msu1regs.asm
@@ -14,7 +14,7 @@
 ;Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 %include "macros.mac"
 
-EXTSYM MSU_CurrentStatus,MSU_MusicVolume,MSU_Track,MSU_Data_Seek,MSU_DATA,MSU_StatusRead,MSU1HandleTrackChange,MSU1HandleStatusBits,MSU1GetStatusBitsSpecial
+EXTSYM MSU_StateControl,MSU_AudioVolume,MSU_Track,MSU_Data_Seek,MSU_DATA,MSU_StatusRead,MSU1HandleTrackChange,MSU1HandleStatusBits,MSU1GetStatusBitsSpecial
 
 SECTION .text
 
@@ -83,11 +83,11 @@ ret
 
 ;VOLUME
 NEWSYM msu1volume
-	mov [MSU_MusicVolume],al
+	mov [MSU_AudioVolume],al
 ret
 
 ;STATE CONTROL
 NEWSYM msu1statecontrol
-	mov [MSU_CurrentStatus],al
+	mov [MSU_StateControl],al
 	ccall MSU1HandleStatusBits
 ret

--- a/chips/msu1regs.asm
+++ b/chips/msu1regs.asm
@@ -30,11 +30,18 @@ ret
 ;DATA read
 NEWSYM msudataread
 	mov ebx,[MSU_DATA]
-	add ebx,[MSU_Data_SeekPort]
-	mov al,[ebx]
+	add ebx,[MSU_Data_Addr]
 
-	;increment seek
-	inc dword[MSU_Data_SeekPort]
+; Reads have no effect when data busy bit set
+	mov	al,[MSU_StatusRead]
+	and al,80h
+	jnz .dontincrement
+
+; Increment data address
+	inc dword[MSU_Data_Addr]
+
+.dontincrement
+	mov al,[ebx]
 ret
 
 ;MSU-1 ID

--- a/chips/msu1regs.c
+++ b/chips/msu1regs.c
@@ -36,7 +36,12 @@ uint8_t msustatusread(void)
 
 uint8_t msudataread(void)
 {
-    return MSU_DATA[MSU_Data_Addr++];
+    // Reads have no effect when data busy bit set
+    if (MSU_StatusRead & MSU_STATUS_DATA_BUSY) {
+        return MSU_DATA[MSU_Data_Addr];
+    } else {
+        return MSU_DATA[MSU_Data_Addr++];
+    }
 }
 
 uint8_t msuid1(void) { return 'S'; }

--- a/chips/msu1regs.c
+++ b/chips/msu1regs.c
@@ -56,10 +56,14 @@ void msudataseek1(uint8_t val) { ((uint8_t*)&MSU_Data_SeekPort)[1] = val; }
 void msudataseek2(uint8_t val) { ((uint8_t*)&MSU_Data_SeekPort)[2] = val; }
 void msudataseek3(uint8_t val)
 {
-    ((uint8_t*)&MSU_Data_SeekPort)[3] = val; // Writing to $2003 triggers seek
-    MSU_StatusRead |= MSU_STATUS_DATA_BUSY; // Start seek, set data busy bit
-    MSU_Data_Addr = MSU_Data_SeekPort; // Set data address to seek port
-    MSU_StatusRead &= ~MSU_STATUS_DATA_BUSY; // Seek finished, clear data busy bit
+    // Writing to $2003 triggers seek
+    ((uint8_t*)&MSU_Data_SeekPort)[3] = val;
+    // Writes have no effect if data busy bit set
+    if (!(MSU_StatusRead & MSU_STATUS_DATA_BUSY)) {
+        MSU_StatusRead |= MSU_STATUS_DATA_BUSY; // Start seek, set data busy bit
+        MSU_Data_Addr = MSU_Data_SeekPort; // Set data address to seek port
+        MSU_StatusRead &= ~MSU_STATUS_DATA_BUSY; // Seek finished, clear data busy bit
+    }
 }
 
 void msu1track0(uint8_t val)

--- a/chips/msu1regs.c
+++ b/chips/msu1regs.c
@@ -56,7 +56,7 @@ void msudataseek1(uint8_t val) { ((uint8_t*)&MSU_Data_SeekPort)[1] = val; }
 void msudataseek2(uint8_t val) { ((uint8_t*)&MSU_Data_SeekPort)[2] = val; }
 void msudataseek3(uint8_t val)
 {
-    ((uint8_t*)&MSU_Data_SeekPort)[3] = val;
+    ((uint8_t*)&MSU_Data_SeekPort)[3] = val; // Writing to $2003 triggers seek
     MSU_StatusRead |= MSU_STATUS_DATA_BUSY; // Start seek, set data busy bit
     MSU_Data_Addr = MSU_Data_SeekPort; // Set data address to seek port
     MSU_StatusRead &= ~MSU_STATUS_DATA_BUSY; // Seek finished, clear data busy bit

--- a/chips/msu1regs.c
+++ b/chips/msu1regs.c
@@ -4,19 +4,21 @@
  * Ported from chips/msu1regs.asm.
  *
  * msustatusread    — calls MSU1GetStatusBitsSpecial then returns MSU_StatusRead
- * msudataread      — returns MSU_DATA[MSU_Data_Seek], increments seek
+ * msudataread      — returns MSU_DATA[MSU_Data_Addr], increments data address
  * msuid1..msuid6   — return the six ID bytes: 'S', '-', 'M', 'S', 'U', '1'
- * msudataseek0..3  — write one byte of MSU_Data_Seek (little-endian byte n)
+ * msudataseek0..3  — write one byte of MSU_Data_SeekPort (little-endian byte n)
  * msu1track0       — write low byte of MSU_Track
  * msu1track1       — write high byte of MSU_Track, then call MSU1HandleTrackChange
  * msu1volume       — write MSU_AudioVolume
  * msu1statecontrol — write MSU_StateControl, then call MSU1HandleStatusBits
  */
 
+#include "msu1emu.h"
 #include <stdint.h>
 
 extern uint8_t MSU_StatusRead;
-extern uint32_t MSU_Data_Seek;
+extern uint32_t MSU_Data_SeekPort;
+extern uint32_t MSU_Data_Addr;
 extern uint8_t* MSU_DATA;
 extern uint16_t MSU_Track;
 extern uint8_t MSU_AudioVolume;
@@ -34,7 +36,7 @@ uint8_t msustatusread(void)
 
 uint8_t msudataread(void)
 {
-    return MSU_DATA[MSU_Data_Seek++];
+    return MSU_DATA[MSU_Data_Addr++];
 }
 
 uint8_t msuid1(void) { return 'S'; }
@@ -44,10 +46,16 @@ uint8_t msuid4(void) { return 'S'; }
 uint8_t msuid5(void) { return 'U'; }
 uint8_t msuid6(void) { return '1'; }
 
-void msudataseek0(uint8_t val) { ((uint8_t*)&MSU_Data_Seek)[0] = val; }
-void msudataseek1(uint8_t val) { ((uint8_t*)&MSU_Data_Seek)[1] = val; }
-void msudataseek2(uint8_t val) { ((uint8_t*)&MSU_Data_Seek)[2] = val; }
-void msudataseek3(uint8_t val) { ((uint8_t*)&MSU_Data_Seek)[3] = val; }
+void msudataseek0(uint8_t val) { ((uint8_t*)&MSU_Data_SeekPort)[0] = val; }
+void msudataseek1(uint8_t val) { ((uint8_t*)&MSU_Data_SeekPort)[1] = val; }
+void msudataseek2(uint8_t val) { ((uint8_t*)&MSU_Data_SeekPort)[2] = val; }
+void msudataseek3(uint8_t val)
+{
+    ((uint8_t*)&MSU_Data_SeekPort)[3] = val;
+    MSU_StatusRead |= MSU_STATUS_DATA_BUSY; // Start seek, set data busy bit
+    MSU_Data_Addr = MSU_Data_SeekPort; // Set data address to seek port
+    MSU_StatusRead &= ~MSU_STATUS_DATA_BUSY; // Seek finished, clear data busy bit
+}
 
 void msu1track0(uint8_t val)
 {

--- a/chips/msu1regs.c
+++ b/chips/msu1regs.c
@@ -9,8 +9,8 @@
  * msudataseek0..3  — write one byte of MSU_Data_Seek (little-endian byte n)
  * msu1track0       — write low byte of MSU_Track
  * msu1track1       — write high byte of MSU_Track, then call MSU1HandleTrackChange
- * msu1volume       — write MSU_MusicVolume
- * msu1statecontrol — write MSU_CurrentStatus, then call MSU1HandleStatusBits
+ * msu1volume       — write MSU_AudioVolume
+ * msu1statecontrol — write MSU_StateControl, then call MSU1HandleStatusBits
  */
 
 #include <stdint.h>
@@ -19,8 +19,8 @@ extern uint8_t MSU_StatusRead;
 extern uint32_t MSU_Data_Seek;
 extern uint8_t* MSU_DATA;
 extern uint16_t MSU_Track;
-extern uint8_t MSU_MusicVolume;
-extern uint8_t MSU_CurrentStatus;
+extern uint8_t MSU_AudioVolume;
+extern uint8_t MSU_StateControl;
 
 extern void MSU1GetStatusBitsSpecial(void);
 extern void MSU1HandleTrackChange(void);
@@ -62,11 +62,11 @@ void msu1track1(uint8_t val)
 
 void msu1volume(uint8_t val)
 {
-    MSU_MusicVolume = val;
+    MSU_AudioVolume = val;
 }
 
 void msu1statecontrol(uint8_t val)
 {
-    MSU_CurrentStatus = val;
+    MSU_StateControl = val;
     MSU1HandleStatusBits();
 }

--- a/test/msu1_test.c
+++ b/test/msu1_test.c
@@ -18,7 +18,8 @@
 /* --- Mock globals -------------------------------------------------------- */
 
 uint8_t MSU_StatusRead;
-uint32_t MSU_Data_Seek;
+uint32_t MSU_Data_SeekPort;
+uint32_t MSU_Data_Addr;
 uint16_t MSU_Track;
 uint8_t MSU_AudioVolume;
 uint8_t MSU_StateControl;
@@ -44,10 +45,11 @@ void MSU1HandleStatusBits(void) { handle_status_calls++; }
         handle_track_calls = 0;                  \
         handle_status_calls = 0;                 \
         MSU_StatusRead = 0;                      \
-        MSU_Data_Seek = 0;                       \
+        MSU_Data_SeekPort = 0;                   \
+        MSU_Data_Addr = 0;                       \
         MSU_Track = 0;                           \
         MSU_AudioVolume = 0;                     \
-        MSU_StateControl = 0;                   \
+        MSU_StateControl = 0;                    \
         memset(mock_data, 0, sizeof(mock_data)); \
     } while (0)
 
@@ -101,22 +103,22 @@ static void test_msudataread(void)
     mock_data[0] = 0x11;
     mock_data[1] = 0x22;
     mock_data[2] = 0x33;
-    MSU_Data_Seek = 0;
+    MSU_Data_SeekPort = 0;
 
     ZT_CHECK(msudataread() == 0x11);
-    ZT_CHECK(MSU_Data_Seek == 1);
+    ZT_CHECK(MSU_Data_SeekPort == 1);
 
     ZT_CHECK(msudataread() == 0x22);
-    ZT_CHECK(MSU_Data_Seek == 2);
+    ZT_CHECK(MSU_Data_SeekPort == 2);
 
     ZT_CHECK(msudataread() == 0x33);
-    ZT_CHECK(MSU_Data_Seek == 3);
+    ZT_CHECK(MSU_Data_SeekPort == 3);
 
     /* seek at arbitrary offset */
     mock_data[100] = 0xAB;
-    MSU_Data_Seek = 100;
+    MSU_Data_SeekPort = 100;
     ZT_CHECK(msudataread() == 0xAB);
-    ZT_CHECK(MSU_Data_Seek == 101);
+    ZT_CHECK(MSU_Data_SeekPort == 101);
 }
 
 static void test_msu_id_chars(void)
@@ -133,27 +135,27 @@ static void test_msu_id_chars(void)
 
 static void test_msudataseek_bytes(void)
 {
-    ZT_SECTION("msudataseek0..3: write individual bytes of MSU_Data_Seek");
+    ZT_SECTION("msudataseek0..3: write individual bytes of MSU_Data_SeekPort");
 
     /* byte 0 — least significant byte */
-    MSU_Data_Seek = 0x12345678u;
+    MSU_Data_SeekPort = 0x12345678u;
     msudataseek0(0xAB);
-    ZT_CHECK(MSU_Data_Seek == 0x123456ABu);
+    ZT_CHECK(MSU_Data_SeekPort == 0x123456ABu);
 
     /* byte 1 */
-    MSU_Data_Seek = 0x12345678u;
+    MSU_Data_SeekPort = 0x12345678u;
     msudataseek1(0xCD);
-    ZT_CHECK(MSU_Data_Seek == 0x1234CD78u);
+    ZT_CHECK(MSU_Data_SeekPort == 0x1234CD78u);
 
     /* byte 2 */
-    MSU_Data_Seek = 0x12345678u;
+    MSU_Data_SeekPort = 0x12345678u;
     msudataseek2(0xEF);
-    ZT_CHECK(MSU_Data_Seek == 0x12EF5678u);
+    ZT_CHECK(MSU_Data_SeekPort == 0x12EF5678u);
 
     /* byte 3 — most significant byte */
-    MSU_Data_Seek = 0x12345678u;
+    MSU_Data_SeekPort = 0x12345678u;
     msudataseek3(0x90);
-    ZT_CHECK(MSU_Data_Seek == 0x90345678u);
+    ZT_CHECK(MSU_Data_SeekPort == 0x90345678u);
 }
 
 static void test_msu1track(void)

--- a/test/msu1_test.c
+++ b/test/msu1_test.c
@@ -20,8 +20,8 @@
 uint8_t MSU_StatusRead;
 uint32_t MSU_Data_Seek;
 uint16_t MSU_Track;
-uint8_t MSU_MusicVolume;
-uint8_t MSU_CurrentStatus;
+uint8_t MSU_AudioVolume;
+uint8_t MSU_StateControl;
 
 static uint8_t mock_data[256];
 uint8_t* MSU_DATA = mock_data;
@@ -46,8 +46,8 @@ void MSU1HandleStatusBits(void) { handle_status_calls++; }
         MSU_StatusRead = 0;                      \
         MSU_Data_Seek = 0;                       \
         MSU_Track = 0;                           \
-        MSU_MusicVolume = 0;                     \
-        MSU_CurrentStatus = 0;                   \
+        MSU_AudioVolume = 0;                     \
+        MSU_StateControl = 0;                   \
         memset(mock_data, 0, sizeof(mock_data)); \
     } while (0)
 
@@ -184,30 +184,30 @@ static void test_msu1track(void)
 
 static void test_msu1volume(void)
 {
-    ZT_SECTION("msu1volume: writes MSU_MusicVolume directly");
+    ZT_SECTION("msu1volume: writes MSU_AudioVolume directly");
 
-    MSU_MusicVolume = 0;
+    MSU_AudioVolume = 0;
     msu1volume(0xFF);
-    ZT_CHECK(MSU_MusicVolume == 0xFF);
+    ZT_CHECK(MSU_AudioVolume == 0xFF);
 
     msu1volume(0x80);
-    ZT_CHECK(MSU_MusicVolume == 0x80);
+    ZT_CHECK(MSU_AudioVolume == 0x80);
 
     msu1volume(0x00);
-    ZT_CHECK(MSU_MusicVolume == 0x00);
+    ZT_CHECK(MSU_AudioVolume == 0x00);
 }
 
 static void test_msu1statecontrol(void)
 {
-    ZT_SECTION("msu1statecontrol: writes MSU_CurrentStatus, calls HandleStatusBits");
+    ZT_SECTION("msu1statecontrol: writes MSU_StateControl, calls HandleStatusBits");
 
     RESET_MOCKS();
     msu1statecontrol(0x03);
-    ZT_CHECK(MSU_CurrentStatus == 0x03);
+    ZT_CHECK(MSU_StateControl == 0x03);
     ZT_CHECK(handle_status_calls == 1);
 
     msu1statecontrol(0x00);
-    ZT_CHECK(MSU_CurrentStatus == 0x00);
+    ZT_CHECK(MSU_StateControl == 0x00);
     ZT_CHECK(handle_status_calls == 2);
 }
 

--- a/win/c_winintrf.c
+++ b/win/c_winintrf.c
@@ -6,8 +6,10 @@
 #include "../c_intrf.h"
 #include "../c_vcache.h"
 #include "../cfg.h"
+#include "../chips/msu1emu.h"
 #include "../cpu/dspproc.h"
 #include "../cpu/execute.h"
+#include "../gblvars.h"
 #include "../gui/c_gui.h"
 #include "../input.h"
 #include "../intrf.h"
@@ -25,6 +27,9 @@
 
 u4 delayvalue;
 u1 blinit;
+
+static const int freqtab[7] = { 8000, 11025, 22050, 44100, 16000, 32000, 48000 };
+#define RATE freqtab[SoundQuality = ((SoundQuality > 6) ? 1 : SoundQuality)]
 
 void StartUp(void) { }
 
@@ -380,6 +385,9 @@ void SoundProcess(void)
         BufferSizeB = 256; // Size
         BufferSizeW = 512;
         asm_call(ProcessSoundBuffer);
+        if (MSUEnable) {
+            mixMSU1Audio(DSPBuffer, DSPBuffer + BufferSizeB, RATE);
+        }
         // DSPBuffer should contain the processed buffer in the specified size
         // You will have to convert/clip it to 16-bit for actual sound process
     }

--- a/zstate.c
+++ b/zstate.c
@@ -284,7 +284,7 @@ static void copy_state_data(uint8_t* buffer, void (*copy_func)(uint8_t**, void*,
     if (MSUEnable) {
         copy_func(&buffer, &MSU_Track_Position, sizeof(MSU_Track_Position));
         copy_func(&buffer, &MSU_StatusRead, sizeof(MSU_StatusRead));
-        copy_func(&buffer, &MSU_MusicVolume, sizeof(MSU_MusicVolume));
+        copy_func(&buffer, &MSU_AudioVolume, sizeof(MSU_AudioVolume));
     }
 
     if (method != csm_load_zst_old) {


### PR DESCRIPTION
This PR Improves MSU-1 emulation further and addresses a few issues.
- Data/audio busy status bits are correctly set/cleared ($2003 write/data seek, $2005 write/track change, audio playback)
- Writes to register $2005 have no effect if audio busy set
- Writes to register $2003 have no effect if data busy set
- Register $2001 reads have no effect if data busy set
- Audio playing status bit cleared when a non-looping audio track ends (fixes [SMW MSU-1](https://www.zeldix.net/t1436-super-mario-world#21209) softlock when exiting levels/intro screen)
- Fixed MSU-1 audio silently playing while emulator is paused
- Fixed MSU-1 audio playback not working on Windows
- General code cleanup

I understand that emulating the busy bit behavior is unnecessary, but I wanted to try to get it close to the behavior of the SD2SNES/FXPak Pro MSU-1 implementation. I haven't actually looked at that code, but I'm familiar with its behavior from programming for it, and that's what I've tried to imitate here.

The only thing I'm uncertain of is the assembly version of msu1regs, I think it should be functionally equivalent to the C version but I'm not absolutely sure (I wasn't certain which was actually being used so I implemented the same changes in both).

Tested with [this SNES Sonic CD FMV demo](https://github.com/KhazWolf/SonicMSU/tree/master/SOURCE), [SMW MSU-1](https://www.zeldix.net/t1436-super-mario-world#21209), and Infidelity's Punch-Out!! port.

The intro FMV does not work in Punch-Out!!, I'm uncertain as to why. The audio works, but not the video, the screen is black. The same likely goes for other MSU-1 software that use ikari01's video player code (many patches and such do). It was already like this before my changes, the real issue could be something further up the chain.