### PR TITLE
Fixes to compile for Windows with MSYS2, Add Windows compilation instructions to README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -562,7 +562,7 @@ SRCS += win/safelib.c
 SRCS += win/winintrf.asm
 SRCS += win/winlink.cpp
 
-LDFLAGS += -ldxguid -ldinput -lgdi32 -lole32 -lwinmm
+LDFLAGS += -ldxguid -ldinput -lgdi32 -lole32 -lwinmm --static
 
 ifdef WITH_OPENGL
 SRCS += win/gl_draw.c

--- a/Makefile
+++ b/Makefile
@@ -562,12 +562,14 @@ SRCS += win/safelib.c
 SRCS += win/winintrf.asm
 SRCS += win/winlink.cpp
 
-LDFLAGS += -ldxguid -ldinput -lgdi32 -lole32 -lwinmm --static
+LDFLAGS += -ldxguid -ldinput -lgdi32 -lole32 -lwinmm
 
 ifdef WITH_OPENGL
 SRCS += win/gl_draw.c
 LDFLAGS += -lopengl32
 endif
+
+LDFLAGS += --static
 
 PSRS += win/confloc.psr
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ make
 
 Run the following commands. Please create a PR if you have issues.
 
-Tested on Windows with WSL installed running Ubuntu 24.04.3 LTS on X86_64.
+Tested on Windows with WSL installed running Ubuntu 24.04.3 LTS on x86_64.
 
 ```sh
 apt update
@@ -83,7 +83,9 @@ make ARCH=win WITH_PNG= CC_TARGET=i686-w64-mingw32-gcc CXX_TARGET=i686-w64-mingw
 
 ### Compiling for Windows with MSYS2
 
-Use MSYS2 MINGW32. Depending on your installation, you may not have a shortcut created for this. If so, locate ``mingw32.exe`` in your MSYS2 installation directory.
+Use MSYS2 MINGW32.
+
+Depending on your installation, you may not have a shortcut created for this. If so, locate ``mingw32.exe`` in your MSYS2 installation directory.
 
 Run the following commands. Please create a PR if you have issues.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,34 @@ apt install -y g++-multilib gcc-multilib libgl-dev libgl-dev:i386 libpng-dev lib
 make
 ```
 
+### Cross-Compiling for Windows on Debian/Ubuntu
+
+Run the following commands. Please create a PR if you have issues.
+
+Tested on Windows with WSL installed running Ubuntu 24.04.3 LTS on X86_64.
+
+```sh
+apt update
+apt install -y git make mingw-w64 libz-mingw-w64-dev nasm python3 pkg-config build-essential
+git clone https://github.com/xyproto/zsnes
+cd zsnes
+make ARCH=win WITH_PNG= CC_TARGET=i686-w64-mingw32-gcc CXX_TARGET=i686-w64-mingw32-g++ CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ WINDRES=i686-w64-mingw32-windres
+```
+
+### Compiling for Windows with MSYS2
+
+Use MSYS2 MINGW32. Depending on your installation, you may not have a shortcut created for this. If so, locate ``mingw32.exe`` in your MSYS2 installation directory.
+
+Run the following commands. Please create a PR if you have issues.
+
+Tested on MSYS2 x86_64 version 20260322.
+
+```sh
+pacman -Syu
+pacman -Sy git make pkg-config nasm python3 mingw-w64-i686-gcc mingw-w64-i686-libpng mingw-w64-i686-zlib mingw-w64-i686-SDL2
+make ARCH=win
+```
+
 ### Pull requests
 
 * Pull requests are welcome.

--- a/win/safelib.c
+++ b/win/safelib.c
@@ -80,7 +80,7 @@ FILE* safe_popen(char* command, const char* mode)
                 intptr_t childpid;
                 flushall();
 
-                childpid = spawnvp(P_NOWAIT, argv[0], (const char* const*)argv);
+                childpid = _spawnvp(P_NOWAIT, argv[0], (const char* const*)argv);
                 if (childpid > 0) {
                     struct fp_pid_link* link = &fp_pids;
                     while (link->next) {


### PR DESCRIPTION
- Pass ``--static`` linker flag for Windows (this fixes missing DLL errors)
- Changed ``spawnvp`` call in ``win\safelib.c`` line 83 to ``_spawnvp`` (this fixes a compiler error on MSYS2)
- Add instructions for cross-compiling for Windows on Debian/Ubuntu
- Add instructions for compiling on Windows with MSYS2