### PR TITLE
Migrate Windows joystick polling from Dinput to Xinput, add SNES rumble controller support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.raw
 *.wav
 build/
+.vscode/
 cfg.h
 config.default
 include.txt

--- a/Makefile
+++ b/Makefile
@@ -543,7 +543,7 @@ SRCS += win/safelib.c
 SRCS += win/winintrf.asm
 SRCS += win/winlink.c
 
-LDFLAGS += -ldxguid -ldinput -lgdi32 -lole32 -lwinmm
+LDFLAGS += -ldxguid -ldinput -lxinput -lgdi32 -lole32 -lwinmm
 
 ifdef WITH_OPENGL
 SRCS += win/gl_draw.c

--- a/c_init.c
+++ b/c_init.c
@@ -46,7 +46,7 @@ u4 JoyENow;
 u4 JoyEOrig;
 u4 numspcvblleft;
 u4 spc700idle;
-u2 RumbleData;    /// SUNLIT RUMBLE CONTROLLER TEST
+u2 RumbleData;    // SUNLIT RUMBLE CONTROLLER TEST
 
 static u1 ComboProg[5];
 static u1 ComboPtr[5];

--- a/c_init.c
+++ b/c_init.c
@@ -46,6 +46,7 @@ u4 JoyENow;
 u4 JoyEOrig;
 u4 numspcvblleft;
 u4 spc700idle;
+u2 RumbleData;    /// SUNLIT RUMBLE CONTROLLER TEST
 
 static u1 ComboProg[5];
 static u1 ComboPtr[5];

--- a/c_init.c
+++ b/c_init.c
@@ -46,8 +46,8 @@ u4 JoyENow;
 u4 JoyEOrig;
 u4 numspcvblleft;
 u4 spc700idle;
-u2 RumbleData; // SUNLIT RUMBLE CONTROLLER TEST
-u1 RumbleTimer = 0; // SUNLIT RUMBLE CONTROLLER TEST
+u2 RumbleData;
+u1 RumbleTimer = 0;
 
 static u1 ComboProg[5];
 static u1 ComboPtr[5];

--- a/c_init.c
+++ b/c_init.c
@@ -46,7 +46,7 @@ u4 JoyENow;
 u4 JoyEOrig;
 u4 numspcvblleft;
 u4 spc700idle;
-u2 RumbleData;    // SUNLIT RUMBLE CONTROLLER TEST
+u2 RumbleData; // SUNLIT RUMBLE CONTROLLER TEST
 
 static u1 ComboProg[5];
 static u1 ComboPtr[5];

--- a/c_init.c
+++ b/c_init.c
@@ -47,6 +47,7 @@ u4 JoyEOrig;
 u4 numspcvblleft;
 u4 spc700idle;
 u2 RumbleData; // SUNLIT RUMBLE CONTROLLER TEST
+u1 RumbleTimer = 0; // SUNLIT RUMBLE CONTROLLER TEST
 
 static u1 ComboProg[5];
 static u1 ComboPtr[5];

--- a/cfg.psr
+++ b/cfg.psr
@@ -40,6 +40,10 @@ GUIComboGameSpec db 0
 GameSpecificInput db 0
 
 @
+@ Enable rumble for player 1 (0 = NO, 1 = Yes)
+SNESRumble db 0
+
+@
 @  ----
 @ -- Options --
 @  ----

--- a/cpu/regs.inc
+++ b/cpu/regs.inc
@@ -679,12 +679,6 @@ NEWSYM reg21C3r
 ; Joystick Data for controller 1 and 2
 
 NEWSYM reg4016r
-    xor al,al
-    test dword[JoyANow],80000000h
-    jz .noal
-    mov al,1
-.noal
-    rol dword[JoyANow],1
     ;/// SUNLIT RUMBLE CONTROLLER TEST
     mov al,[ioportval]  ; Get IO port value
 	cmp al,0FFh	 ; is it set to $FF?
@@ -697,6 +691,13 @@ NEWSYM reg4016r
     rol word[RumbleData],1 ; rotate left
 .dontrol
     ;/// SUNLIT RUMBLE CONTROLLER TEST
+
+    xor al,al
+    test dword[JoyANow],80000000h
+    jz .noal
+    mov al,1
+.noal
+    rol dword[JoyANow],1
     ret
 
 SECTION .bss

--- a/cpu/regs.inc
+++ b/cpu/regs.inc
@@ -22,7 +22,7 @@
 EXTSYM SPC7110Enable,curypos,cycpl
 EXTSYM pdh,vram,romispal,reg1read,spcnumread,spcon,reg2read,reg3read
 EXTSYM reg4read,JoyEOrig,JoyENow,device2,cycphb,joycontren,totlines
-EXTSYM RumbleData ;// SUNLIT RUMBLE CONTROLLER TEST
+EXTSYM RumbleData
 
 %ifndef NO_DEBUGGER
 EXTSYM debuggeron
@@ -679,18 +679,16 @@ NEWSYM reg21C3r
 ; Joystick Data for controller 1 and 2
 
 NEWSYM reg4016r
-    ;// SUNLIT RUMBLE CONTROLLER TEST
-    mov al,[ioportval]  ; Get IO port value
-    cmp al,0FFh	 ; is it set to $FF?
-    je .donerumble  ; if yes, skip all this
-    and al,040h    ; isolate IO bit 6 (controller 1 I/O)
-    shr al,6       ; shift into bit 0
-    or  [RumbleData],al ; insert bit
+    mov al,[ioportval]          ; Get IO port value
+    cmp al,0FFh                 ; is it set to $FF?
+    je .donerumble              ; if yes, skip all this
+    and al,040h                 ; isolate IO bit 6 (controller 1 I/O)
+    shr al,6                    ; shift into bit 0
+    or  [RumbleData],al         ; insert bit
     cmp byte[RumbleData+1],072h ; is hi byte == rumble sentry?
-    je .donerumble ; yes, don't rotate any further 
-    rol word[RumbleData],1 ; rotate left
+    je .donerumble              ; yes, don't rotate any further 
+    rol word[RumbleData],1      ; rotate left
 .donerumble
-    ;// SUNLIT RUMBLE CONTROLLER TEST
 
     xor al,al
     test dword[JoyANow],80000000h

--- a/cpu/regs.inc
+++ b/cpu/regs.inc
@@ -22,6 +22,7 @@
 EXTSYM SPC7110Enable,curypos,cycpl
 EXTSYM pdh,vram,romispal,reg1read,spcnumread,spcon,reg2read,reg3read
 EXTSYM reg4read,JoyEOrig,JoyENow,device2,cycphb,joycontren,totlines
+EXTSYM RumbleData ;/// SUNLIT RUMBLE CONTROLLER TEST
 
 %ifndef NO_DEBUGGER
 EXTSYM debuggeron
@@ -684,6 +685,18 @@ NEWSYM reg4016r
     mov al,1
 .noal
     rol dword[JoyANow],1
+    ;/// SUNLIT RUMBLE CONTROLLER TEST
+    mov al,[ioportval]  ; Get IO port value
+	cmp al,0FFh	 ; is it set to $FF?
+	je .dontrol  ; if yes, skip all this
+    and al,040h    ; isolate IO bit 6 (controller 1 I/O)
+    shr al,6       ; shift into bit 0
+    or  [RumbleData],al ; insert bit
+    cmp byte[RumbleData+1],072h ; is hi byte == rumble sentry?
+    je .dontrol ; yes, don't rotate any further 
+    rol word[RumbleData],1 ; rotate left
+.dontrol
+    ;/// SUNLIT RUMBLE CONTROLLER TEST
     ret
 
 SECTION .bss

--- a/cpu/regs.inc
+++ b/cpu/regs.inc
@@ -22,7 +22,7 @@
 EXTSYM SPC7110Enable,curypos,cycpl
 EXTSYM pdh,vram,romispal,reg1read,spcnumread,spcon,reg2read,reg3read
 EXTSYM reg4read,JoyEOrig,JoyENow,device2,cycphb,joycontren,totlines
-EXTSYM RumbleData ;/// SUNLIT RUMBLE CONTROLLER TEST
+EXTSYM RumbleData ;// SUNLIT RUMBLE CONTROLLER TEST
 
 %ifndef NO_DEBUGGER
 EXTSYM debuggeron
@@ -679,18 +679,18 @@ NEWSYM reg21C3r
 ; Joystick Data for controller 1 and 2
 
 NEWSYM reg4016r
-    ;/// SUNLIT RUMBLE CONTROLLER TEST
+    ;// SUNLIT RUMBLE CONTROLLER TEST
     mov al,[ioportval]  ; Get IO port value
-	cmp al,0FFh	 ; is it set to $FF?
-	je .dontrol  ; if yes, skip all this
+    cmp al,0FFh	 ; is it set to $FF?
+    je .donerumble  ; if yes, skip all this
     and al,040h    ; isolate IO bit 6 (controller 1 I/O)
     shr al,6       ; shift into bit 0
     or  [RumbleData],al ; insert bit
     cmp byte[RumbleData+1],072h ; is hi byte == rumble sentry?
-    je .dontrol ; yes, don't rotate any further 
+    je .donerumble ; yes, don't rotate any further 
     rol word[RumbleData],1 ; rotate left
-.dontrol
-    ;/// SUNLIT RUMBLE CONTROLLER TEST
+.donerumble
+    ;// SUNLIT RUMBLE CONTROLLER TEST
 
     xor al,al
     test dword[JoyANow],80000000h

--- a/cpu/regsw.inc
+++ b/cpu/regsw.inc
@@ -23,6 +23,7 @@ EXTSYM reg420Bw,reg420Cw,regptwa,NextLineCache,vidmemch2,vidmemch4
 EXTSYM vidmemch8,vrama,nmirept,SPCRAM,HIRQCycNext,HIRQNextExe,tableadc
 EXTSYM cycpb268,cycpb358,cycpbl,cycpblt,opexec268,opexec268cph,opexec358
 EXTSYM opexec358cph
+EXTSYM RumbleData ;/// SUNLIT RUMBLE CONTROLLER TEST
 
 %ifndef NO_DEBUGGER
 EXTSYM sndwrit,debstop

--- a/cpu/regsw.inc
+++ b/cpu/regsw.inc
@@ -23,7 +23,6 @@ EXTSYM reg420Bw,reg420Cw,regptwa,NextLineCache,vidmemch2,vidmemch4
 EXTSYM vidmemch8,vrama,nmirept,SPCRAM,HIRQCycNext,HIRQNextExe,tableadc
 EXTSYM cycpb268,cycpb358,cycpbl,cycpblt,opexec268,opexec268cph,opexec358
 EXTSYM opexec358cph
-EXTSYM RumbleData ;/// SUNLIT RUMBLE CONTROLLER TEST
 
 %ifndef NO_DEBUGGER
 EXTSYM sndwrit,debstop

--- a/gui/c_guiwindp.c
+++ b/gui/c_guiwindp.c
@@ -871,6 +871,7 @@ void DisplayGUIInput(void)
 
     GUIDisplayCheckboxu(3, 5, 160, &GameSpecificInput, "GAME SPECIFIC", 0);
     GUIDisplayCheckboxu(3, 5, 170, &AllowUDLR, "ALLOW U+D/L+R", 0);
+    GUIDisplayCheckboxu(3, 105, 160, &SNESRumble, "P1 Rumble", 3);
     GUIDisplayCheckboxu(3, 105, 170, &Turbo30hz, "TURBO AT 30HZ", 0);
     GUIDisplayCheckboxu(3, 5, 180, &pl12s34, "USE PL3/4 AS PL1/2", 0);
 

--- a/gui/guifuncs.c
+++ b/gui/guifuncs.c
@@ -356,6 +356,7 @@ void GUIRestoreVars()
     CheckValueBounds(&device2, 0, 4, 0, UB);
     CheckValueBounds(&GUIComboGameSpec, 0, 1, 0, UB);
     CheckValueBounds(&GameSpecificInput, 0, 1, 0, UB);
+    CheckValueBounds(&SNESRumble, 0, 1, 0, UB);
 
 #ifdef __WIN32__
     CheckValueBounds(&PauseFocusChange, 0, 1, 0, UB);

--- a/gui/guikeys.c
+++ b/gui/guikeys.c
@@ -338,6 +338,7 @@ static void GUIInputKeys(char dh)
         GUIFreshInputSelect = 1;
     }
     GUIKeyCheckbox(&GameSpecificInput, 'G', dh);
+    GUIKeyCheckbox(&SNESRumble, 'R', dh);
     GUIKeyCheckbox(&AllowUDLR, 'A', dh);
     GUIKeyCheckbox(&Turbo30hz, 'T', dh);
     if (dh == 'U') {

--- a/gui/guimouse.c
+++ b/gui/guimouse.c
@@ -857,6 +857,7 @@ static void DisplayGUIInputClick_skipscrol(s4 const eax, s4 const edx)
     }
 
     GUIClickCButton(eax, edx, 5, 160, &GameSpecificInput);
+    GUIClickCButton(eax, edx, 105, 160, &SNESRumble);
     GUIClickCButton(eax, edx, 5, 170, &AllowUDLR);
     GUIClickCButton(eax, edx, 105, 170, &Turbo30hz);
     GUIClickCButtonM(eax, edx, 5, 180, &pl12s34);

--- a/linux/sdllink.c
+++ b/linux/sdllink.c
@@ -53,16 +53,6 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #include <X11/Xlib.h>
 
-#ifdef __SDL3__
-#define SDL_RUMBLECONTROLLER(gamepad, left, right, time) SDL_RumbleGamepad(gamepad, left, right, time)
-#define SDL_OPENCONTROLLER(index) SDL_OpenGamepad(index)
-#else
-#define SDL_RUMBLECONTROLLER(gamepad, left, right, time) SDL_JoystickRumble(gamepad, left, right, time)
-#define SDL_OPENCONTROLLER(index) SDL_GameControllerOpen(index)
-#endif
-
-SDL_Gamepad* gamepad = SDL_OPENCONTROLLER(0);
-
 _Noreturn void zexit_error(void);
 
 typedef enum {

--- a/linux/sdllink.c
+++ b/linux/sdllink.c
@@ -61,7 +61,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #define SDL_OPENCONTROLLER(index) SDL_GameControllerOpen(index)
 #endif
 
-SDL_Gamepad *gamepad = SDL_OPENCONTROLLER(0);
+SDL_Gamepad* gamepad = SDL_OPENCONTROLLER(0);
 
 _Noreturn void zexit_error(void);
 

--- a/linux/sdllink.c
+++ b/linux/sdllink.c
@@ -1649,33 +1649,22 @@ void DoRumble(void)
     }
 
     if (RumbleData == 0xFFFF) {
-        printf("Null rumble data hit!\n");
         RumbleData = 0;
-    }
-
-    if (RumbleData != 0) {
-        printf("RumbleData: $%X\n", RumbleData);
     }
 
     if ((RumbleData & 0xFF00) == 0x7200) {
-        printf("Rumble sentry hit!\n");
         u2 RumbleLeft = ((RumbleData & 0x000F) * 4369);
-        printf("Left: $%X\n", RumbleLeft);
         u2 RumbleRight = (((RumbleData & 0x00F0) >> 4) * 4369);
-        printf("Right: $%X\n", RumbleRight);
-        bool result = SDL_JoystickRumble(JoystickInput[0], RumbleLeft, RumbleRight, 500);
+        SDL_JoystickRumble(JoystickInput[0], RumbleLeft, RumbleRight, 500);
         RumbleTimer++;
-
         RumbleData = 0;
-
-        if (result == true) {
-            printf("Rumble started!\n");
-        }
     }
 }
 
 void UpdateVFrame(void)
 {
+    extern u1 MultiTap;
+
     // Quick fix for GUI CPU usage
     if (GUIOn || GUIOn2 || EMUPause) {
         usleep(6000);
@@ -1684,7 +1673,7 @@ void UpdateVFrame(void)
     CheckTimers();
     Main_Proc();
 
-    if (SNESRumble) {
+    if (SNESRumble && !MultiTap) {
         DoRumble();
     } else {
         // Stop vibration

--- a/linux/sdllink.c
+++ b/linux/sdllink.c
@@ -1057,7 +1057,7 @@ BOOL InitJoystickInput()
         num_hats = SDL_JoystickNumHats(JoystickInput[i]);
         num_balls = SDL_JoystickNumBalls(JoystickInput[i]);
         printf("Device %i %s\n", i, SDL_JoystickName(JoystickInput[i]));
-        printf("  %i axis, %i buttons, %i hats, %i balls\n", num_axes, num_buttons, num_hats,
+        printf("  %i axis, %i buttons, %i hats, %i balls, %i rumble\n", num_axes, num_buttons, num_hats,
             num_balls);
 
         if (next_offset >= 448) {
@@ -1640,16 +1640,12 @@ static void sem_sleep_die()
 
 void DoRumble(void)
 {
-    SDL_Gamepad* gamepad = SDL_OPENCONTROLLER(0);
     extern u2 RumbleData;
     extern u1 RumbleTimer;
 
     if (RumbleTimer == 60) {
         // Stop vibration
-        SDL_RUMBLECONTROLLER(gamepad, 0, 0, 1);
-#ifdef __SDL3__
-        SDL_UpdateJoysticks();
-#endif
+        SDL_JoystickRumble(JoystickInput[0], 0, 0, 1);
     }
 
     if (RumbleData == 0xFFFF) {
@@ -1667,10 +1663,7 @@ void DoRumble(void)
         printf("Left: $%X\n", RumbleLeft);
         u2 RumbleRight = (((RumbleData & 0x00F0) >> 4) * 4369);
         printf("Right: $%X\n", RumbleRight);
-        bool result = SDL_RUMBLECONTROLLER(gamepad, RumbleLeft, RumbleRight, 2000);
-#ifdef __SDL3__
-        SDL_UpdateJoysticks();
-#endif
+        bool result = SDL_JoystickRumble(JoystickInput[0], RumbleLeft, RumbleRight, 500);
         RumbleTimer++;
 
         RumbleData = 0;
@@ -1691,15 +1684,11 @@ void UpdateVFrame(void)
     CheckTimers();
     Main_Proc();
 
-    SDL_Gamepad* gamepad = SDL_OPENCONTROLLER(0);
     if (SNESRumble) {
         DoRumble();
     } else {
         // Stop vibration
-        SDL_RUMBLECONTROLLER(gamepad, 0, 0, 1);
-#ifdef __SDL3__
-        SDL_UpdateJoysticks();
-#endif
+        SDL_RumbleJoystick(JoystickInput[0], 0, 0, 1);
     }
 
     if (sound_sdl) {

--- a/linux/sdllink.c
+++ b/linux/sdllink.c
@@ -1643,9 +1643,10 @@ void DoRumble(void)
     extern u2 RumbleData;
     extern u1 RumbleTimer;
 
-    if (RumbleTimer == 60) {
+    if (RumbleTimer >= 60) {
         // Stop vibration
         SDL_JoystickRumble(JoystickInput[0], 0, 0, 1);
+        RumbleTimer = 0;
     }
 
     if (RumbleData == 0xFFFF) {

--- a/linux/sdllink.c
+++ b/linux/sdllink.c
@@ -53,6 +53,16 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #include <X11/Xlib.h>
 
+#ifdef __SDL3__
+#define SDL_RUMBLECONTROLLER(gamepad, left, right, time) SDL_RumbleGamepad(gamepad, left, right, time)
+#define SDL_OPENCONTROLLER(index) SDL_OpenGamepad(index)
+#else
+#define SDL_RUMBLECONTROLLER(gamepad, left, right, time) SDL_GameControllerRumble(gamepad, left, right, time)
+#define SDL_OPENCONTROLLER(index) SDL_GameControllerOpen(index)
+#endif
+
+SDL_Gamepad *gamepad = SDL_OPENCONTROLLER(0);
+
 _Noreturn void zexit_error(void);
 
 typedef enum {
@@ -1628,6 +1638,42 @@ static void sem_sleep_die()
     }
 }
 
+void DoRumble(void)
+{
+    extern u2 RumbleData;
+    extern u1 RumbleTimer;
+
+    if (RumbleTimer == 60) {
+        // Stop vibration
+        SDL_RUMBLECONTROLLER(gamepad,0,0,1);
+    }
+
+    if (RumbleData == 0xFFFF) {
+        printf("Null rumble data hit!\n");
+        RumbleData = 0;
+    }
+
+    if (RumbleData != 0) {
+        printf("RumbleData: $%X\n", RumbleData);
+    }
+
+    if ((RumbleData & 0xFF00) == 0x7200) {
+        printf("Rumble sentry hit!\n");
+        u2 RumbleLeft = ((RumbleData & 0x000F) * 4369);
+        printf("Left: $%X\n", RumbleLeft);
+        u2 RumbleRight = (((RumbleData & 0x00F0) >> 4) * 4369);
+        printf("Right: $%X\n", RumbleRight);
+        SDL_RUMBLECONTROLLER(gamepad,((RumbleData & 0x000F) * 4369),(((RumbleData & 0x00F0) >> 4) * 4369),500);
+        RumbleTimer++;
+
+        RumbleData = 0;
+
+        if (result == ERROR_SUCCESS) {
+            printf("Rumble started!\n");
+        }
+    }
+}
+
 void UpdateVFrame(void)
 {
     // Quick fix for GUI CPU usage
@@ -1637,6 +1683,13 @@ void UpdateVFrame(void)
 
     CheckTimers();
     Main_Proc();
+
+    if (SNESRumble) {
+        DoRumble();
+    } else {
+        // Stop vibration
+        SDL_RUMBLECONTROLLER(gamepad,0,0,1);
+    }
 
     if (sound_sdl) {
         SoundWrite_sdl();

--- a/linux/sdllink.c
+++ b/linux/sdllink.c
@@ -1057,7 +1057,7 @@ BOOL InitJoystickInput()
         num_hats = SDL_JoystickNumHats(JoystickInput[i]);
         num_balls = SDL_JoystickNumBalls(JoystickInput[i]);
         printf("Device %i %s\n", i, SDL_JoystickName(JoystickInput[i]));
-        printf("  %i axis, %i buttons, %i hats, %i balls, %i rumble\n", num_axes, num_buttons, num_hats,
+        printf("  %i axis, %i buttons, %i hats, %i balls\n", num_axes, num_buttons, num_hats,
             num_balls);
 
         if (next_offset >= 448) {

--- a/linux/sdllink.c
+++ b/linux/sdllink.c
@@ -57,7 +57,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #define SDL_RUMBLECONTROLLER(gamepad, left, right, time) SDL_RumbleGamepad(gamepad, left, right, time)
 #define SDL_OPENCONTROLLER(index) SDL_OpenGamepad(index)
 #else
-#define SDL_RUMBLECONTROLLER(gamepad, left, right, time) SDL_GameControllerRumble(gamepad, left, right, time)
+#define SDL_RUMBLECONTROLLER(gamepad, left, right, time) SDL_JoystickRumble(gamepad, left, right, time)
 #define SDL_OPENCONTROLLER(index) SDL_GameControllerOpen(index)
 #endif
 
@@ -1640,12 +1640,16 @@ static void sem_sleep_die()
 
 void DoRumble(void)
 {
+    SDL_Gamepad* gamepad = SDL_OPENCONTROLLER(0);
     extern u2 RumbleData;
     extern u1 RumbleTimer;
 
     if (RumbleTimer == 60) {
         // Stop vibration
-        SDL_RUMBLECONTROLLER(gamepad,0,0,1);
+        SDL_RUMBLECONTROLLER(gamepad, 0, 0, 1);
+#ifdef __SDL3__
+        SDL_UpdateJoysticks();
+#endif
     }
 
     if (RumbleData == 0xFFFF) {
@@ -1663,12 +1667,15 @@ void DoRumble(void)
         printf("Left: $%X\n", RumbleLeft);
         u2 RumbleRight = (((RumbleData & 0x00F0) >> 4) * 4369);
         printf("Right: $%X\n", RumbleRight);
-        SDL_RUMBLECONTROLLER(gamepad,((RumbleData & 0x000F) * 4369),(((RumbleData & 0x00F0) >> 4) * 4369),500);
+        bool result = SDL_RUMBLECONTROLLER(gamepad, RumbleLeft, RumbleRight, 2000);
+#ifdef __SDL3__
+        SDL_UpdateJoysticks();
+#endif
         RumbleTimer++;
 
         RumbleData = 0;
 
-        if (result == ERROR_SUCCESS) {
+        if (result == true) {
             printf("Rumble started!\n");
         }
     }
@@ -1684,11 +1691,15 @@ void UpdateVFrame(void)
     CheckTimers();
     Main_Proc();
 
+    SDL_Gamepad* gamepad = SDL_OPENCONTROLLER(0);
     if (SNESRumble) {
         DoRumble();
     } else {
         // Stop vibration
-        SDL_RUMBLECONTROLLER(gamepad,0,0,1);
+        SDL_RUMBLECONTROLLER(gamepad, 0, 0, 1);
+#ifdef __SDL3__
+        SDL_UpdateJoysticks();
+#endif
     }
 
     if (sound_sdl) {

--- a/linux/sdllink.c
+++ b/linux/sdllink.c
@@ -1641,13 +1641,6 @@ static void sem_sleep_die()
 void DoRumble(void)
 {
     extern u2 RumbleData;
-    extern u1 RumbleTimer;
-
-    if (RumbleTimer >= 60) {
-        // Stop vibration
-        SDL_JoystickRumble(JoystickInput[0], 0, 0, 1);
-        RumbleTimer = 0;
-    }
 
     if (RumbleData == 0xFFFF) {
         RumbleData = 0;
@@ -1656,8 +1649,7 @@ void DoRumble(void)
     if ((RumbleData & 0xFF00) == 0x7200) {
         u2 RumbleLeft = ((RumbleData & 0x000F) * 4369);
         u2 RumbleRight = (((RumbleData & 0x00F0) >> 4) * 4369);
-        SDL_JoystickRumble(JoystickInput[0], RumbleLeft, RumbleRight, 500);
-        RumbleTimer++;
+        SDL_JoystickRumble(JoystickInput[0], RumbleLeft, RumbleRight, 600);
         RumbleData = 0;
     }
 }

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -1680,34 +1680,22 @@ void DoRumble(void)
     }
 
     if (RumbleData == 0xFFFF) {
-        printf("Null rumble data hit!\n");
         RumbleData = 0;
-    }
-
-    if (RumbleData != 0) {
-        printf("RumbleData: $%X\n", RumbleData);
     }
 
     if ((RumbleData & 0xFF00) == 0x7200) {
-        printf("Rumble sentry hit!\n");
         vibration.wLeftMotorSpeed = ((RumbleData & 0x000F) * 4369);
-        printf("Left: $%X\n", vibration.wLeftMotorSpeed);
         vibration.wRightMotorSpeed = (((RumbleData & 0x00F0) >> 4) * 4369);
-        printf("Right: $%X\n", vibration.wRightMotorSpeed);
-        DWORD result = XInputSetState(0, &vibration); // controller index 0
+        XInputSetState(0, &vibration); // controller index 0
         RumbleTimer++;
-
         RumbleData = 0;
-
-        if (result == ERROR_SUCCESS) {
-            printf("Rumble started!\n");
-        }
     }
 }
 
 volatile int SPCSize;
 void UpdateVFrame(void)
 {
+    extern u1 MultiTap;
     static uint32_t LastUsedPos = 0;
 
     int DataNeeded;
@@ -1715,7 +1703,7 @@ void UpdateVFrame(void)
 
     // if (StereoSound==1) SPCSize=256;
 
-    if (SNESRumble) {
+    if (SNESRumble && !MultiTap) {
         DoRumble();
     } else {
         // Stop vibration

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -23,6 +23,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #define DIRECTSOUND_VERSION 0x0800
 #define __STDC_CONSTANT_MACROS
 #define COBJMACROS
+#define ANALOG_DEADZONE 16000
 
 #include <ctype.h>
 #include <math.h>
@@ -30,6 +31,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include <stdint.h>
 #include <stdio.h>
 
+#include <Xinput.h>
 #include <dinput.h>
 #include <dsound.h>
 #include <windows.h>
@@ -94,28 +96,9 @@ DWORD dwBytes2;
 LPDIRECTINPUT8 DInput = NULL;
 LPDIRECTINPUTDEVICE8 MouseInput = NULL;
 LPDIRECTINPUTDEVICE8 KeyboardInput = NULL;
-LPDIRECTINPUTDEVICE8 JoystickInput[5];
-DIJOYSTATE js[5];
-
-DWORD X1Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD X2Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD Y1Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD Y2Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD Z1Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD Z2Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD RX1Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD RX2Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD RY1Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD RY2Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD RZ1Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD RZ2Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD S01Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD S02Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD S11Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD S12Disable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD POVDisable[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD NumPOV[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-DWORD NumBTN[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+XINPUT_STATE xstate[4];
+BOOL XInputConnected[4];
+DWORD result;
 
 DWORD CurrentJoy = 0;
 
@@ -280,12 +263,6 @@ void reInitSound()
 
 BOOL InputAcquire()
 {
-    for (unsigned int i = 0; i < 5; i++) {
-        if (JoystickInput[i]) {
-            IDirectInputDevice8_Acquire(JoystickInput[i]);
-        }
-    }
-
     if (device1 && device2 && !GUIOn2) {
         MultiMouseInit();
     } else if (MouseInput && GUIOn2) {
@@ -302,12 +279,6 @@ BOOL InputDeAcquire()
 {
     if (KeyboardInput) {
         IDirectInputDevice8_Unacquire(KeyboardInput);
-    }
-
-    for (unsigned int i = 0; i < 5; i++) {
-        if (JoystickInput[i]) {
-            IDirectInputDevice8_Unacquire(JoystickInput[i]);
-        }
     }
 
     if (device1 && device2 && !GUIOn2) {
@@ -1023,153 +994,6 @@ BOOL ReInitSound()
     }
 }
 
-BOOL FAR PASCAL InitJoystickInput(LPCDIDEVICEINSTANCE pdinst, LPVOID pvRef)
-{
-    LPDIRECTINPUT8 pdi = (LPDIRECTINPUT8)pvRef;
-    GUID DeviceGuid = pdinst->guidInstance;
-
-    if (CurrentJoy > 4) {
-        return DIENUM_CONTINUE;
-    }
-
-    // Create the DirectInput joystick device.
-    if (IDirectInput8_CreateDevice(pdi, &DeviceGuid, &JoystickInput[CurrentJoy], NULL) != DI_OK) {
-        return DIENUM_CONTINUE;
-    }
-
-    if (IDirectInputDevice8_SetDataFormat(JoystickInput[CurrentJoy], &c_dfDIJoystick) != DI_OK) {
-        IDirectInputDevice8_Release(JoystickInput[CurrentJoy]);
-        return DIENUM_CONTINUE;
-    }
-
-    if (IDirectInputDevice8_SetCooperativeLevel(JoystickInput[CurrentJoy], hMainWindow,
-            DISCL_EXCLUSIVE | DISCL_BACKGROUND)
-        != DI_OK) {
-        IDirectInputDevice8_Release(JoystickInput[CurrentJoy]);
-        return DIENUM_CONTINUE;
-    }
-
-    DIPROPRANGE diprg;
-
-    diprg.diph.dwSize = sizeof(diprg);
-    diprg.diph.dwHeaderSize = sizeof(diprg.diph);
-    diprg.diph.dwObj = DIJOFS_X;
-    diprg.diph.dwHow = DIPH_BYOFFSET;
-    diprg.lMin = joy_sensitivity * -1;
-    diprg.lMax = joy_sensitivity;
-
-    if (FAILED(IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_RANGE, &diprg.diph))) {
-        X1Disable[CurrentJoy] = 1;
-        X2Disable[CurrentJoy] = 1;
-    }
-
-    diprg.diph.dwObj = DIJOFS_Y;
-
-    if (FAILED(IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_RANGE, &diprg.diph))) {
-        Y1Disable[CurrentJoy] = 1;
-        Y2Disable[CurrentJoy] = 1;
-    }
-
-    diprg.diph.dwObj = DIJOFS_Z;
-    if (FAILED(IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_RANGE, &diprg.diph))) {
-        Z1Disable[CurrentJoy] = 1;
-        Z2Disable[CurrentJoy] = 1;
-    }
-
-    diprg.diph.dwObj = DIJOFS_RX;
-    if (FAILED(IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_RANGE, &diprg.diph))) {
-        RX1Disable[CurrentJoy] = 1;
-        RX2Disable[CurrentJoy] = 1;
-    }
-
-    diprg.diph.dwObj = DIJOFS_RY;
-    if (FAILED(IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_RANGE, &diprg.diph))) {
-        RY1Disable[CurrentJoy] = 1;
-        RY2Disable[CurrentJoy] = 1;
-    }
-
-    diprg.diph.dwObj = DIJOFS_RZ;
-    if (FAILED(IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_RANGE, &diprg.diph))) {
-        RZ1Disable[CurrentJoy] = 1;
-        RZ2Disable[CurrentJoy] = 1;
-    }
-
-    diprg.diph.dwObj = DIJOFS_SLIDER(0);
-    if (FAILED(IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_RANGE, &diprg.diph))) {
-        S01Disable[CurrentJoy] = 1;
-        S02Disable[CurrentJoy] = 1;
-    }
-
-    diprg.diph.dwObj = DIJOFS_SLIDER(1);
-    if (FAILED(IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_RANGE, &diprg.diph))) {
-        S11Disable[CurrentJoy] = 1;
-        S12Disable[CurrentJoy] = 1;
-    }
-
-    DIDEVCAPS didc;
-
-    didc.dwSize = sizeof(DIDEVCAPS);
-
-    if (IDirectInputDevice8_GetCapabilities(JoystickInput[CurrentJoy], &didc) != DI_OK) {
-        IDirectInputDevice8_Release(JoystickInput[CurrentJoy]);
-        return DIENUM_CONTINUE;
-    }
-
-    if (didc.dwButtons <= 16) {
-        NumBTN[CurrentJoy] = didc.dwButtons;
-    } else {
-        NumBTN[CurrentJoy] = 16;
-    }
-
-    if (didc.dwPOVs) {
-        NumPOV[CurrentJoy] = didc.dwPOVs;
-    } else {
-        POVDisable[CurrentJoy] = 1;
-    }
-
-    DIPROPDWORD dipdw;
-
-    dipdw.diph.dwSize = sizeof(DIPROPDWORD);
-    dipdw.diph.dwHeaderSize = sizeof(dipdw.diph);
-    dipdw.diph.dwHow = DIPH_BYOFFSET;
-    dipdw.dwData = 2500;
-    dipdw.diph.dwObj = DIJOFS_X;
-    IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_DEADZONE, &dipdw.diph);
-
-    dipdw.diph.dwObj = DIJOFS_Y;
-    IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_DEADZONE, &dipdw.diph);
-
-    dipdw.diph.dwObj = DIJOFS_Z;
-    IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_DEADZONE, &dipdw.diph);
-
-    dipdw.diph.dwObj = DIJOFS_RX;
-    IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_DEADZONE, &dipdw.diph);
-
-    dipdw.diph.dwObj = DIJOFS_RY;
-    IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_DEADZONE, &dipdw.diph);
-
-    dipdw.diph.dwObj = DIJOFS_RZ;
-    IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_DEADZONE, &dipdw.diph);
-
-    dipdw.diph.dwObj = DIJOFS_SLIDER(0);
-    IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_DEADZONE, &dipdw.diph);
-
-    dipdw.diph.dwObj = DIJOFS_SLIDER(1);
-    IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_DEADZONE, &dipdw.diph);
-
-    dipdw.diph.dwSize = sizeof(DIPROPDWORD);
-    dipdw.diph.dwHeaderSize = sizeof(dipdw.diph);
-    dipdw.diph.dwHow = DIPH_DEVICE;
-    dipdw.dwData = DIPROPAXISMODE_ABS;
-    dipdw.diph.dwObj = 0;
-
-    IDirectInputDevice8_SetProperty(JoystickInput[CurrentJoy], DIPROP_AXISMODE, &dipdw.diph);
-
-    CurrentJoy += 1;
-
-    return DIENUM_CONTINUE;
-}
-
 void ReleaseDirectInput()
 {
     if (MouseInput) {
@@ -1180,13 +1004,6 @@ void ReleaseDirectInput()
     if (KeyboardInput) {
         IDirectInputDevice8_Release(KeyboardInput);
         KeyboardInput = NULL;
-    }
-
-    for (int i = 0; i < 5; i++) {
-        if (JoystickInput[i]) {
-            IDirectInputDevice8_Release(JoystickInput[i]);
-            JoystickInput[i] = NULL;
-        }
     }
 
     if (DInput) {
@@ -1292,17 +1109,10 @@ static bool InitInput(HINSTANCE const hInst)
         return FALSE;
     }
 
-    JoystickInput[0] = NULL;
-    JoystickInput[1] = NULL;
-    JoystickInput[2] = NULL;
-    JoystickInput[3] = NULL;
-    JoystickInput[4] = NULL;
-
-    hr = IDirectInput8_EnumDevices(DInput, DI8DEVCLASS_GAMECTRL, InitJoystickInput, DInput, DIEDFL_ATTACHEDONLY);
-
-    if (FAILED(hr)) {
-        DInputError();
-        return FALSE;
+    for (DWORD i = 0; i < 4; i++) {
+        ZeroMemory(&xstate[i], sizeof(XINPUT_STATE));
+        result = XInputGetState(i, &xstate[i]);
+        XInputConnected[i] = (result == ERROR_SUCCESS);
     }
 
     InputAcquire();
@@ -1314,74 +1124,9 @@ void TestJoy()
 {
     int i;
 
-    for (i = 0; i < 5; i++) {
-        if (JoystickInput[i]) {
-            IDirectInputDevice8_Poll(JoystickInput[i]);
-
-            if (IDirectInputDevice8_GetDeviceState(JoystickInput[i], sizeof(DIJOYSTATE), &js[i]) == DIERR_INPUTLOST) {
-                if (JoystickInput[i]) {
-                    IDirectInputDevice8_Acquire(JoystickInput[i]);
-                }
-                if (FAILED(IDirectInputDevice8_GetDeviceState(JoystickInput[i], sizeof(DIJOYSTATE), &js[i]))) {
-                    return;
-                }
-            }
-
-            if (!X1Disable[i] && (js[i].lX > 0)) {
-                X1Disable[i] = 1;
-            }
-
-            if (!X2Disable[i] && (js[i].lX < 0)) {
-                X2Disable[i] = 1;
-            }
-
-            if (!Y1Disable[i] && (js[i].lY > 0)) {
-                Y1Disable[i] = 1;
-            }
-
-            if (!Y2Disable[i] && (js[i].lY < 0)) {
-                Y2Disable[i] = 1;
-            }
-
-            if (!Z1Disable[i] && (js[i].lZ > 0)) {
-                Z1Disable[i] = 1;
-            }
-
-            if (!Z2Disable[i] && (js[i].lZ < 0)) {
-                Z2Disable[i] = 1;
-            }
-
-            if (!RY1Disable[i] && (js[i].lRy > 0)) {
-                RY1Disable[i] = 1;
-            }
-
-            if (!RY2Disable[i] && (js[i].lRy < 0)) {
-                RY2Disable[i] = 1;
-            }
-
-            if (!RZ1Disable[i] && (js[i].lRz > 0)) {
-                RZ1Disable[i] = 1;
-            }
-
-            if (!RZ2Disable[i] && (js[i].lRz < 0)) {
-                RZ2Disable[i] = 1;
-            }
-
-            if (!S01Disable[i] && (js[i].rglSlider[0] > 0)) {
-                S01Disable[i] = 1;
-            }
-
-            if (!S02Disable[i] && (js[i].rglSlider[0] < 0)) {
-                S02Disable[i] = 1;
-            }
-
-            if (!S11Disable[i] && (js[i].rglSlider[1] > 0)) {
-                S11Disable[i] = 1;
-            }
-
-            if (!S12Disable[i] && (js[i].rglSlider[1] < 0)) {
-                S12Disable[i] = 1;
-            }
+    for (i = 0; i < 4; i++) {
+        if (result != ERROR_SUCCESS) {
+            continue;
         }
     }
 }
@@ -2391,6 +2136,9 @@ void WinUpdateDevices()
     unsigned char* keys;
     unsigned char keys2[256];
 
+    result = XInputGetState(i, &xstate[i]);
+    XInputConnected[i] = (result == ERROR_SUCCESS);
+
     for (i = 0; i < 256; i++) {
         keys2[i] = 0;
     }
@@ -2425,152 +2173,155 @@ void WinUpdateDevices()
 
     keys[0] = 0;
 
-    for (i = 0; i < 5; i++) {
-        if (JoystickInput[i]) {
-            for (j = 0; j < 32; j++) {
-                keys[0x100 + i * 32 + j] = 0;
+    for (i = 0; i < 4; i++) {
+        if (XInputConnected[i]) {
+
+            if (result != ERROR_SUCCESS) {
+                continue;
             }
 
-            IDirectInputDevice8_Poll(JoystickInput[i]);
-
-            if (IDirectInputDevice8_GetDeviceState(JoystickInput[i], sizeof(DIJOYSTATE), &js[i]) == DIERR_INPUTLOST) {
-                if (JoystickInput[i]) {
-                    IDirectInputDevice8_Acquire(JoystickInput[i]);
-                }
-                if (FAILED(IDirectInputDevice8_GetDeviceState(JoystickInput[i], sizeof(DIJOYSTATE), &js[i]))) {
-                    return;
-                }
+            if (xstate[i].Gamepad.sThumbLX > ANALOG_DEADZONE) {
+                keys[0x100 + i * 32 + 0] = 1;
+            } else {
+                keys[0x100 + i * 32 + 0] = 0;
             }
 
-            if (!X1Disable[i]) {
-                if (js[i].lX > 0) {
-                    keys[0x100 + i * 32 + 0] = 1;
-                }
+            if (xstate[i].Gamepad.sThumbLX < -ANALOG_DEADZONE) {
+                keys[0x100 + i * 32 + 1] = 1;
+            } else {
+                keys[0x100 + i * 32 + 1] = 0;
             }
 
-            if (!X2Disable[i]) {
-                if (js[i].lX < 0) {
-                    keys[0x100 + i * 32 + 1] = 1;
-                }
+            if (xstate[i].Gamepad.sThumbLY > ANALOG_DEADZONE) {
+                keys[0x100 + i * 32 + 2] = 1;
+            } else {
+                keys[0x100 + i * 32 + 2] = 0;
             }
 
-            if (!Y1Disable[i]) {
-                if (js[i].lY > 0) {
-                    keys[0x100 + i * 32 + 2] = 1;
-                }
+            if (xstate[i].Gamepad.sThumbLY < -ANALOG_DEADZONE) {
+                keys[0x100 + i * 32 + 3] = 1;
+            } else {
+                keys[0x100 + i * 32 + 3] = 0;
             }
 
-            if (!Y2Disable[i]) {
-                if (js[i].lY < 0) {
-                    keys[0x100 + i * 32 + 3] = 1;
-                }
+            if (xstate[i].Gamepad.sThumbRX > ANALOG_DEADZONE) {
+                keys[0x100 + i * 32 + 4] = 1;
+            } else {
+                keys[0x100 + i * 32 + 4] = 0;
             }
 
-            if (!Z1Disable[i]) {
-                if (js[i].lZ > 0) {
-                    keys[0x100 + i * 32 + 4] = 1;
-                }
+            if (xstate[i].Gamepad.sThumbRX < -ANALOG_DEADZONE) {
+                keys[0x100 + i * 32 + 5] = 1;
+            } else {
+                keys[0x100 + i * 32 + 5] = 0;
             }
 
-            if (!Z2Disable[i]) {
-                if (js[i].lZ < 0) {
-                    keys[0x100 + i * 32 + 5] = 1;
-                }
+            if (xstate[i].Gamepad.sThumbRY > ANALOG_DEADZONE) {
+                keys[0x100 + i * 32 + 6] = 1;
+            } else {
+                keys[0x100 + i * 32 + 6] = 0;
             }
 
-            if (!RY1Disable[i]) {
-                if (js[i].lRy > 0) {
-                    keys[0x100 + i * 32 + 6] = 1;
-                }
+            if (xstate[i].Gamepad.sThumbRY < -ANALOG_DEADZONE) {
+                keys[0x100 + i * 32 + 7] = 1;
+            } else {
+                keys[0x100 + i * 32 + 7] = 0;
             }
 
-            if (!RY2Disable[i]) {
-                if (js[i].lRy < 0) {
-                    keys[0x100 + i * 32 + 7] = 1;
-                }
+            if (xstate[i].Gamepad.bLeftTrigger > ANALOG_DEADZONE) {
+                keys[0x100 + i * 32 + 8] = 1;
+            } else {
+                keys[0x100 + i * 32 + 8] = 0;
             }
 
-            if (!RZ1Disable[i]) {
-                if (js[i].lRz > 0) {
-                    keys[0x100 + i * 32 + 8] = 1;
-                }
+            if (xstate[i].Gamepad.bRightTrigger > ANALOG_DEADZONE) {
+                keys[0x100 + i * 32 + 9] = 1;
+            } else {
+                keys[0x100 + i * 32 + 9] = 0;
             }
 
-            if (!RZ2Disable[i]) {
-                if (js[i].lRz < 0) {
-                    keys[0x100 + i * 32 + 9] = 1;
-                }
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_UP) {
+                keys[0x100 + i * 32 + 10] = 1;
+            } else {
+                keys[0x100 + i * 32 + 10] = 0;
             }
 
-            if (!S01Disable[i]) {
-                if (js[i].rglSlider[0] > 0) {
-                    keys[0x100 + i * 32 + 10] = 1;
-                }
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_DOWN) {
+                keys[0x100 + i * 32 + 11] = 1;
+            } else {
+                keys[0x100 + i * 32 + 11] = 0;
             }
 
-            if (!S02Disable[i]) {
-                if (js[i].rglSlider[0] < 0) {
-                    keys[0x100 + i * 32 + 11] = 1;
-                }
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_LEFT) {
+                keys[0x100 + i * 32 + 12] = 1;
+            } else {
+                keys[0x100 + i * 32 + 12] = 0;
             }
 
-            if (!S11Disable[i]) {
-                if (js[i].rglSlider[1] > 0) {
-                    keys[0x100 + i * 32 + 12] = 1;
-                }
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_RIGHT) {
+                keys[0x100 + i * 32 + 13] = 1;
+            } else {
+                keys[0x100 + i * 32 + 13] = 0;
             }
 
-            if (!S12Disable[i]) {
-                if (js[i].rglSlider[1] < 0) {
-                    keys[0x100 + i * 32 + 13] = 1;
-                }
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_START) {
+                keys[0x100 + i * 32 + 14] = 1;
+            } else {
+                keys[0x100 + i * 32 + 14] = 0;
             }
 
-            if (!POVDisable[i]) {
-                for (int p = 0; (unsigned long)p < NumPOV[i]; p++) {
-                    switch (js[i].rgdwPOV[p]) {
-                    case 0:
-                        keys[0x100 + i * 32 + 3] = 1;
-                        break;
-                    case 4500:
-                        keys[0x100 + i * 32 + 0] = 1;
-                        keys[0x100 + i * 32 + 3] = 1;
-                        break;
-                    case 9000:
-                        keys[0x100 + i * 32 + 0] = 1;
-                        break;
-                    case 13500:
-                        keys[0x100 + i * 32 + 0] = 1;
-                        keys[0x100 + i * 32 + 2] = 1;
-                        break;
-                    case 18000:
-                        keys[0x100 + i * 32 + 2] = 1;
-                        break;
-                    case 22500:
-                        keys[0x100 + i * 32 + 1] = 1;
-                        keys[0x100 + i * 32 + 2] = 1;
-                        break;
-                    case 27000:
-                        keys[0x100 + i * 32 + 1] = 1;
-                        break;
-                    case 31500:
-                        keys[0x100 + i * 32 + 1] = 1;
-                        keys[0x100 + i * 32 + 3] = 1;
-                        break;
-                    }
-                }
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_BACK) {
+                keys[0x100 + i * 32 + 15] = 1;
+            } else {
+                keys[0x100 + i * 32 + 15] = 0;
             }
 
-            if (NumBTN[i]) {
-                for (j = 0; (unsigned long)j < NumBTN[i]; j++) {
-                    if (js[i].rgbButtons[j]) {
-                        keys[0x100 + i * 32 + 16 + j] = 1;
-                    }
-                }
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_LEFT_THUMB) {
+                keys[0x100 + i * 32 + 16] = 1;
+            } else {
+                keys[0x100 + i * 32 + 16] = 0;
             }
-        } else {
-            for (j = 0; j < 32; j++) {
-                keys[0x100 + i * 32 + j] = 0;
+
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_RIGHT_THUMB) {
+                keys[0x100 + i * 32 + 17] = 1;
+            } else {
+                keys[0x100 + i * 32 + 17] = 0;
+            }
+
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER) {
+                keys[0x100 + i * 32 + 18] = 1;
+            } else {
+                keys[0x100 + i * 32 + 18] = 0;
+            }
+
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER) {
+                keys[0x100 + i * 32 + 19] = 1;
+            } else {
+                keys[0x100 + i * 32 + 19] = 0;
+            }
+
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_A) {
+                keys[0x100 + i * 32 + 20] = 1;
+            } else {
+                keys[0x100 + i * 32 + 20] = 0;
+            }
+
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_B) {
+                keys[0x100 + i * 32 + 21] = 1;
+            } else {
+                keys[0x100 + i * 32 + 21] = 0;
+            }
+
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_X) {
+                keys[0x100 + i * 32 + 22] = 1;
+            } else {
+                keys[0x100 + i * 32 + 22] = 0;
+            }
+
+            if (xstate[i].Gamepad.wButtons & XINPUT_GAMEPAD_Y) {
+                keys[0x100 + i * 32 + 23] = 1;
+            } else {
+                keys[0x100 + i * 32 + 23] = 0;
             }
         }
     }

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -1677,7 +1677,7 @@ void DoRumble(void)
         // Stop vibration
         ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
         XInputSetState(0, &vibration);
-		RumbleTimer = 0;
+        RumbleTimer = 0;
     }
 
     if (RumbleData == 0xFFFF) {

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -1667,6 +1667,45 @@ void CheckTimers(void)
     }
 }
 
+void DoRumble(void)
+{
+    // SUNLIT RUMBLE CONTROLLER TEST
+    extern u2 RumbleData;
+    double intensity = 10; // ideally this would be in the options, range should be 1.0 - 10.0
+    XINPUT_VIBRATION vibration = { 0 };
+
+    if (RumbleData == 0) {
+        // Stop vibration
+        ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
+        XInputSetState(0, &vibration);
+    }
+
+    if (RumbleData == 0xFFFF) {
+        printf("Null rumble data hit!\n");
+        RumbleData = 0;
+    }
+
+    if (RumbleData != 0) {
+        printf("RumbleData: $%X\n", RumbleData);
+    }
+
+    if ((RumbleData & 0xFF00) == 0x7200) {
+        printf("Rumble sentry hit!\n");
+        vibration.wLeftMotorSpeed = (((RumbleData & 0x000F) * 4369) * intensity);
+        printf("Left: $%X\n", vibration.wLeftMotorSpeed);
+        vibration.wRightMotorSpeed = ((((RumbleData & 0x00F0) >> 4) * 4369) * intensity);
+        printf("Right: $%X\n", vibration.wRightMotorSpeed);
+        DWORD result = XInputSetState(0, &vibration); // controller index 0
+
+        RumbleData = 0;
+
+        if (result == ERROR_SUCCESS) {
+            printf("Rumble started!\n");
+        }
+    }
+    // SUNLIT RUMBLE CONTROLLER TEST
+}
+
 volatile int SPCSize;
 void UpdateVFrame(void)
 {
@@ -1676,6 +1715,8 @@ void UpdateVFrame(void)
     SPCSize = 256;
 
     // if (StereoSound==1) SPCSize=256;
+
+    DoRumble(); // SUNLIT RUMBLE CONTROLLER TEST
 
     while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
         TranslateMessage(&msg);
@@ -2129,54 +2170,14 @@ void drawscreenwin(void)
         DDDrawScreen();
 }
 
-void DoRumble(void)
-{
-	// SUNLIT RUMBLE CONTROLLER TEST
-	extern u2 RumbleData;
-	double intensity = 10; // ideally this would be in the options, range should be 1.0 - 10.0
-	XINPUT_VIBRATION vibration = {0};
-
-	if(RumbleData == 0) {
-		// Stop vibration
-		ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
-		XInputSetState(0, &vibration);
-	}
-
-	if(RumbleData == 0xFFFF) {
-		printf("Null rumble data hit!\n");
-		RumbleData = 0;
-	}
-
-	if (RumbleData != 0) {
-		printf("RumbleData: $%X\n", RumbleData);
-	}
-
-	if ((RumbleData & 0xFF00) == 0x7200) {
-		printf("Rumble sentry hit!\n");
-		vibration.wLeftMotorSpeed  = (((RumbleData & 0x000F) * 4369) * intensity);
-		printf("Left: $%X\n",vibration.wLeftMotorSpeed);
-		vibration.wRightMotorSpeed = ((((RumbleData & 0x00F0) >> 4) * 4369) * intensity);
-		printf("Right: $%X\n",vibration.wRightMotorSpeed);
-		DWORD result = XInputSetState(0, &vibration); // controller index 0
-
-		RumbleData = 0;
-
-		if (result == ERROR_SUCCESS) {
-			printf("Rumble started!\n");
-		}
-	}
-	// SUNLIT RUMBLE CONTROLLER TEST
-}
-
 void WinUpdateDevices()
 {
-	DoRumble();
     int i, j;
     unsigned char* keys;
     unsigned char keys2[256];
 
     for (int i = 0; i < 4; i++) {
-        //ZeroMemory(&xstate[i], sizeof(XINPUT_STATE));
+        // ZeroMemory(&xstate[i], sizeof(XINPUT_STATE));
         result = XInputGetState(i, &xstate[i]);
         XInputConnected[i] = (result == ERROR_SUCCESS);
     }

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -31,11 +31,11 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include <stdint.h>
 #include <stdio.h>
 
-#include <xinput.h>
 #include <dinput.h>
 #include <dsound.h>
 #include <windows.h>
 #include <winuser.h>
+#include <xinput.h>
 
 #include "../asm_call.h"
 #include "../c_init.h"

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -65,6 +65,8 @@ void zexit_error(void);
 #include "../debugger/load.h"
 #endif
 
+u2 RumbleWait = 0;
+
 DWORD Moving = 0;
 DWORD SoundBufferSize = 1024 * 18;
 DWORD FirstSound = 1;
@@ -2131,6 +2133,48 @@ void drawscreenwin(void)
 
 void WinUpdateDevices()
 {
+    /// SUNLIT RUMBLE CONTROLLER TEST
+    // Rumble Test
+    extern u2 RumbleData;
+    extern u1 ioportval;
+    XINPUT_VIBRATION vibration = {0};
+	//if(RumbleData == 0xFFFF) {
+	//	RumbleData = 0;
+	//}
+	//if(RumbleData != 0) {
+		printf("RumbleData: $%X\n", RumbleData);
+	//}
+    if ((RumbleData & 0xFF00) == 0x7200) {
+		printf("Rumble sentry hit!\n");
+		printf("RumbleWait: $%X\n", RumbleWait);
+		vibration.wLeftMotorSpeed  = ((RumbleData & 0x000F) * 4369);
+		printf("LeftRumble: $%X\n",vibration.wLeftMotorSpeed);
+		vibration.wRightMotorSpeed = (((RumbleData & 0x00F0) >> 4) * 4369);
+		printf("RightRumble: $%X\n",vibration.wRightMotorSpeed);
+		//if(RumbleWait != 255) {
+		DWORD result = XInputSetState(0, &vibration); // controller index 0
+		//RumbleWait++;
+		//} else {
+    	//Sleep(2000); // vibrate for 2 seconds
+		RumbleData = 0;
+		//ioportval = 0;
+		//}
+		if (result == ERROR_SUCCESS)
+		{
+			printf("Vibration started\n");
+		}
+		else
+		{
+			printf("Failed to set vibration: %lu\n", result);
+		}
+		// Stop vibration
+		ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
+		XInputSetState(0, &vibration);
+    } else {
+		RumbleData = 0;
+	}
+    /// SUNLIT RUMBLE CONTROLLER TEST
+
     int i, j;
     unsigned char* keys;
     unsigned char keys2[256];

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -1671,10 +1671,10 @@ void DoRumble(void)
 {
     // SUNLIT RUMBLE CONTROLLER TEST
     extern u2 RumbleData;
-    double intensity = 10; // ideally this would be in the options, range should be 1.0 - 10.0
+    extern u1 RumbleTimer;
     XINPUT_VIBRATION vibration = { 0 };
 
-    if (RumbleData == 0) {
+    if (RumbleTimer == 60) {
         // Stop vibration
         ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
         XInputSetState(0, &vibration);
@@ -1691,11 +1691,12 @@ void DoRumble(void)
 
     if ((RumbleData & 0xFF00) == 0x7200) {
         printf("Rumble sentry hit!\n");
-        vibration.wLeftMotorSpeed = (((RumbleData & 0x000F) * 4369) * intensity);
+        vibration.wLeftMotorSpeed = ((RumbleData & 0x000F) * 4369);
         printf("Left: $%X\n", vibration.wLeftMotorSpeed);
-        vibration.wRightMotorSpeed = ((((RumbleData & 0x00F0) >> 4) * 4369) * intensity);
+        vibration.wRightMotorSpeed = (((RumbleData & 0x00F0) >> 4) * 4369);
         printf("Right: $%X\n", vibration.wRightMotorSpeed);
         DWORD result = XInputSetState(0, &vibration); // controller index 0
+        RumbleTimer++;
 
         RumbleData = 0;
 

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -100,8 +100,6 @@ XINPUT_STATE xstate[4];
 BOOL XInputConnected[4];
 DWORD result;
 
-DWORD CurrentJoy = 0;
-
 BYTE BitDepth;
 BYTE BackColor = 0;
 DEVMODE mode;
@@ -1109,7 +1107,7 @@ static bool InitInput(HINSTANCE const hInst)
         return FALSE;
     }
 
-    for (DWORD i = 0; i < 4; i++) {
+    for (int i = 0; i < 4; i++) {
         ZeroMemory(&xstate[i], sizeof(XINPUT_STATE));
         result = XInputGetState(i, &xstate[i]);
         XInputConnected[i] = (result == ERROR_SUCCESS);
@@ -1125,6 +1123,7 @@ void TestJoy()
     int i;
 
     for (i = 0; i < 4; i++) {
+        result = XInputGetState(i, &xstate[i]);
         if (result != ERROR_SUCCESS) {
             continue;
         }
@@ -2136,8 +2135,11 @@ void WinUpdateDevices()
     unsigned char* keys;
     unsigned char keys2[256];
 
-    result = XInputGetState(i, &xstate[i]);
-    XInputConnected[i] = (result == ERROR_SUCCESS);
+    for (int i = 0; i < 4; i++) {
+        //ZeroMemory(&xstate[i], sizeof(XINPUT_STATE));
+        result = XInputGetState(i, &xstate[i]);
+        XInputConnected[i] = (result == ERROR_SUCCESS);
+    }
 
     for (i = 0; i < 256; i++) {
         keys2[i] = 0;
@@ -2175,10 +2177,6 @@ void WinUpdateDevices()
 
     for (i = 0; i < 4; i++) {
         if (XInputConnected[i]) {
-
-            if (result != ERROR_SUCCESS) {
-                continue;
-            }
 
             if (xstate[i].Gamepad.sThumbLX > ANALOG_DEADZONE) {
                 keys[0x100 + i * 32 + 0] = 1;

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -1673,10 +1673,11 @@ void DoRumble(void)
     extern u2 RumbleData;
     extern u1 RumbleTimer;
 
-    if (RumbleTimer == 60) {
+    if (RumbleTimer >= 60) {
         // Stop vibration
         ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
         XInputSetState(0, &vibration);
+		RumbleTimer = 0;
     }
 
     if (RumbleData == 0xFFFF) {

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -99,6 +99,7 @@ LPDIRECTINPUTDEVICE8 KeyboardInput = NULL;
 XINPUT_STATE xstate[4];
 BOOL XInputConnected[4];
 DWORD result;
+XINPUT_VIBRATION vibration = { 0 };
 
 BYTE BitDepth;
 BYTE BackColor = 0;
@@ -1669,10 +1670,8 @@ void CheckTimers(void)
 
 void DoRumble(void)
 {
-    // SUNLIT RUMBLE CONTROLLER TEST
     extern u2 RumbleData;
     extern u1 RumbleTimer;
-    XINPUT_VIBRATION vibration = { 0 };
 
     if (RumbleTimer == 60) {
         // Stop vibration
@@ -1704,7 +1703,6 @@ void DoRumble(void)
             printf("Rumble started!\n");
         }
     }
-    // SUNLIT RUMBLE CONTROLLER TEST
 }
 
 volatile int SPCSize;
@@ -1717,7 +1715,13 @@ void UpdateVFrame(void)
 
     // if (StereoSound==1) SPCSize=256;
 
-    DoRumble(); // SUNLIT RUMBLE CONTROLLER TEST
+    if (SNESRumble) {
+        DoRumble();
+    } else {
+        // Stop vibration
+        ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
+        XInputSetState(0, &vibration);
+    }
 
     while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
         TranslateMessage(&msg);

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -31,7 +31,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #include <stdint.h>
 #include <stdio.h>
 
-#include <Xinput.h>
+#include <xinput.h>
 #include <dinput.h>
 #include <dsound.h>
 #include <windows.h>

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -2228,13 +2228,14 @@ void WinUpdateDevices()
                 keys[0x100 + i * 32 + 7] = 0;
             }
 
-            if (xstate[i].Gamepad.bLeftTrigger > ANALOG_DEADZONE) {
+            // Analog triggers' range is 0 - 255
+            if (xstate[i].Gamepad.bLeftTrigger > 0) {
                 keys[0x100 + i * 32 + 8] = 1;
             } else {
                 keys[0x100 + i * 32 + 8] = 0;
             }
 
-            if (xstate[i].Gamepad.bRightTrigger > ANALOG_DEADZONE) {
+            if (xstate[i].Gamepad.bRightTrigger > 0) {
                 keys[0x100 + i * 32 + 9] = 1;
             } else {
                 keys[0x100 + i * 32 + 9] = 0;

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -65,8 +65,6 @@ void zexit_error(void);
 #include "../debugger/load.h"
 #endif
 
-u2 RumbleWait = 0;
-
 DWORD Moving = 0;
 DWORD SoundBufferSize = 1024 * 18;
 DWORD FirstSound = 1;
@@ -2131,50 +2129,46 @@ void drawscreenwin(void)
         DDDrawScreen();
 }
 
-void WinUpdateDevices()
+void DoRumble(void)
 {
-    /// SUNLIT RUMBLE CONTROLLER TEST
-    // Rumble Test
-    extern u2 RumbleData;
-    extern u1 ioportval;
-    XINPUT_VIBRATION vibration = {0};
-	//if(RumbleData == 0xFFFF) {
-	//	RumbleData = 0;
-	//}
-	//if(RumbleData != 0) {
-		printf("RumbleData: $%X\n", RumbleData);
-	//}
-    if ((RumbleData & 0xFF00) == 0x7200) {
-		printf("Rumble sentry hit!\n");
-		printf("RumbleWait: $%X\n", RumbleWait);
-		vibration.wLeftMotorSpeed  = ((RumbleData & 0x000F) * 4369);
-		printf("LeftRumble: $%X\n",vibration.wLeftMotorSpeed);
-		vibration.wRightMotorSpeed = (((RumbleData & 0x00F0) >> 4) * 4369);
-		printf("RightRumble: $%X\n",vibration.wRightMotorSpeed);
-		//if(RumbleWait != 255) {
-		DWORD result = XInputSetState(0, &vibration); // controller index 0
-		//RumbleWait++;
-		//} else {
-    	//Sleep(2000); // vibrate for 2 seconds
-		RumbleData = 0;
-		//ioportval = 0;
-		//}
-		if (result == ERROR_SUCCESS)
-		{
-			printf("Vibration started\n");
-		}
-		else
-		{
-			printf("Failed to set vibration: %lu\n", result);
-		}
+	/// SUNLIT RUMBLE CONTROLLER TEST
+	extern u2 RumbleData;
+	double intensity = 10; // ideally this would be in the options, range should be 1.0 - 10.0
+	XINPUT_VIBRATION vibration = {0};
+
+	if(RumbleData == 0) {
 		// Stop vibration
 		ZeroMemory(&vibration, sizeof(XINPUT_VIBRATION));
 		XInputSetState(0, &vibration);
-    } else {
+	}
+
+	if(RumbleData == 0xFFFF) {
 		RumbleData = 0;
 	}
-    /// SUNLIT RUMBLE CONTROLLER TEST
 
+	if (RumbleData != 0) {
+		printf("RumbleData: $%X\n", RumbleData);
+	}
+
+	if ((RumbleData & 0xFF00) == 0x7200) {
+		printf("Rumble sentry hit!\n");
+		vibration.wLeftMotorSpeed  = (((RumbleData & 0x000F) * 4369) * intensity);
+		printf("LeftRumble: $%X\n",vibration.wLeftMotorSpeed);
+		vibration.wRightMotorSpeed = ((((RumbleData & 0x00F0) >> 4) * 4369) * intensity);
+		printf("RightRumble: $%X\n",vibration.wRightMotorSpeed);
+		DWORD result = XInputSetState(0, &vibration); // controller index 0
+
+		RumbleData = 0;
+
+		if (result == ERROR_SUCCESS) {
+			printf("Vibration started\n");
+		}
+	}
+}
+
+void WinUpdateDevices()
+{
+	DoRumble();
     int i, j;
     unsigned char* keys;
     unsigned char keys2[256];

--- a/win/winlink.c
+++ b/win/winlink.c
@@ -2131,7 +2131,7 @@ void drawscreenwin(void)
 
 void DoRumble(void)
 {
-	/// SUNLIT RUMBLE CONTROLLER TEST
+	// SUNLIT RUMBLE CONTROLLER TEST
 	extern u2 RumbleData;
 	double intensity = 10; // ideally this would be in the options, range should be 1.0 - 10.0
 	XINPUT_VIBRATION vibration = {0};
@@ -2143,6 +2143,7 @@ void DoRumble(void)
 	}
 
 	if(RumbleData == 0xFFFF) {
+		printf("Null rumble data hit!\n");
 		RumbleData = 0;
 	}
 
@@ -2153,17 +2154,18 @@ void DoRumble(void)
 	if ((RumbleData & 0xFF00) == 0x7200) {
 		printf("Rumble sentry hit!\n");
 		vibration.wLeftMotorSpeed  = (((RumbleData & 0x000F) * 4369) * intensity);
-		printf("LeftRumble: $%X\n",vibration.wLeftMotorSpeed);
+		printf("Left: $%X\n",vibration.wLeftMotorSpeed);
 		vibration.wRightMotorSpeed = ((((RumbleData & 0x00F0) >> 4) * 4369) * intensity);
-		printf("RightRumble: $%X\n",vibration.wRightMotorSpeed);
+		printf("Right: $%X\n",vibration.wRightMotorSpeed);
 		DWORD result = XInputSetState(0, &vibration); // controller index 0
 
 		RumbleData = 0;
 
 		if (result == ERROR_SUCCESS) {
-			printf("Vibration started\n");
+			printf("Rumble started!\n");
 		}
 	}
+	// SUNLIT RUMBLE CONTROLLER TEST
 }
 
 void WinUpdateDevices()


### PR DESCRIPTION
The primary goal of this PR was to add [SNES rumble controller](https://github.com/LimitedRunGames-Tech/snes-rumble) support, but because triggering rumble on Dinput is more complicated, I migrated the Windows joystick polling to Xinput to make this easier. Keyboard and mouse polling on Windows are still handled by Dinput.
Only 4 controllers can be connected now instead of 5, this is a limitation of Xinput. This also allows for controllers to be reconnected without restarting ZSNES on Windows.

Both the Windows (Xinput) and Linux (SDL) backends have working rumble support for the first controller connected. Rumble can be enabled by checking "P1 Rumble" in Config -> Input. Rumble is skipped when a multitap is connected and is only allowed for player 1 as the specification requires.

Tested with [Randy's test ROM](https://github.com/LimitedRunGames-Tech/snes-rumble/blob/main/binaries/RT.SFC), Infidelity's Punch-Out!! port, [Attack of the PETSCII Robots](https://romhackplaza.org/romhacks/attack-of-the-petscii-robots-rumble-support-snes/), and a yet unreleased patch for F-Zero.