### PR TITLE
Add StartupWMClass to zsnes.desktop

### DIFF
--- a/linux/zsnes.desktop
+++ b/linux/zsnes.desktop
@@ -8,6 +8,7 @@ TryExec=zsnes
 Icon=io.github.xyproto.zsnes
 Terminal=false
 StartupNotify=false
+StartupWMClass=zsnes
 X-SingleMainWindow=true
 Categories=Game;Emulator;
 MimeType=application/vnd.nintendo.snes.rom;application/x-snes-rom;


### PR DESCRIPTION
This ensures that the main window can be matched with the .desktop file.