### PR TITLE
Bound interleaved ROM block tables

### DIFF
--- a/initc.c
+++ b/initc.c
@@ -199,13 +199,13 @@ void SwapData(uint32_t* loc1, uint32_t* loc2, uint32_t amount)
     }
 }
 
-void swapBlocks(uint8_t* blocks)
+void swapBlocks(uint32_t* blocks)
 {
     uint_fast32_t i, j;
     for (i = 0; i < NumofBanks; i++) {
         for (j = 0; j < NumofBanks; j++) {
-            if (blocks[j] == (int8_t)i) {
-                int8_t b;
+            if (blocks[j] == i) {
+                uint32_t b;
                 SwapData(((uint32_t*)romdata + blocks[i] * 0x2000), ((uint32_t*)romdata + blocks[j] * 0x2000), 0x2000);
                 b = blocks[j];
                 blocks[j] = blocks[i];
@@ -218,14 +218,19 @@ void swapBlocks(uint8_t* blocks)
 
 void deintlv1()
 {
-    uint8_t blocks[256];
+    uint32_t* blocks;
     int_fast32_t i;
     int32_t numblocks = NumofBanks / 2;
+
+    blocks = malloc(sizeof(*blocks) * NumofBanks);
+    if (!blocks)
+        return;
     for (i = 0; i < numblocks; i++) {
         blocks[i * 2] = i + numblocks;
         blocks[i * 2 + 1] = i;
     }
     swapBlocks(blocks);
+    free(blocks);
 }
 
 void CheckIntl1(uint8_t* ROM)

--- a/initc.c
+++ b/initc.c
@@ -80,6 +80,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 #define MB_bytes 0x100000
 #define Mbit_bytes 0x20000
+#define MaxInterleaveBanks (0xC00000 / 0x8000)
 
 // Offsets to add to infoloc start to reach particular variable
 #define BankOffset 21 // Contains Speed as well
@@ -218,19 +219,20 @@ void swapBlocks(uint32_t* blocks)
 
 void deintlv1()
 {
-    uint32_t* blocks;
+    uint32_t blocks[MaxInterleaveBanks];
     int_fast32_t i;
     int32_t numblocks = NumofBanks / 2;
 
-    blocks = malloc(sizeof(*blocks) * NumofBanks);
-    if (!blocks)
+    if (NumofBanks > MaxInterleaveBanks)
         return;
+    for (i = 0; i < NumofBanks; i++) {
+        blocks[i] = i;
+    }
     for (i = 0; i < numblocks; i++) {
         blocks[i * 2] = i + numblocks;
         blocks[i * 2 + 1] = i;
     }
     swapBlocks(blocks);
-    free(blocks);
 }
 
 void CheckIntl1(uint8_t* ROM)


### PR DESCRIPTION
This fixes a stack buffer overflow when opening oversized interleaved ROMs.

During ROM setup, `SetupROM` calls `BankCheck`, which can call `CheckIntl1` and `deintlv1` to rearrange interleaved ROM banks. `deintlv1` used a fixed 256-byte table even though the loader supports ROMs with more than 256 banks. It also stored bank indices in byte-sized entries, which could not represent larger ROMs correctly.

The block table is now allocated for the current bank count and uses full-width indices. The table is initialized with identity mappings before interleaving entries are applied, keeping all entries defined for both even and odd bank counts.