### PR TITLE
Bound SuperFX ROM expansion

### DIFF
--- a/initc.c
+++ b/initc.c
@@ -1960,6 +1960,7 @@ void preparesfx()
 {
     char* ROM = (char*)romdata;
     int_fast16_t i;
+    uint32_t const rom_buffer_size = (uint32_t)(sfxramdata - romdata);
 
     SfxAC = 0;
 
@@ -1968,6 +1969,9 @@ void preparesfx()
     }
 
     // [sneed]: bigger rom support
+    // Keep the expanded ROM below the reserved SuperFX RAM area.
+    if (NumofBanks > rom_buffer_size / 0x10000)
+        return;
     for (i = (NumofBanks - 1); i >= 0; i--) {
         memcpy((int32_t*)romdata + i * 0x4000, (int32_t*)romdata + i * 0x2000, 0x8000);
         memcpy((int32_t*)romdata + i * 0x4000 + 0x2000, (int32_t*)romdata + i * 0x2000, 0x8000);


### PR DESCRIPTION
This fixes an out-of-bounds write when opening oversized SuperFX ROMs.

During ROM setup, `chip_detect` identifies SuperFX cartridges from the ROM header. `initsnes` then selects `map_sfx`, which calls `preparesfx` to expand each 32 KiB ROM bank into the 64 KiB layout expected by the mapper.

The expansion previously did not account for the memory layout reserved by `romaptr`. Once the expanded ROM reached `sfxramdata`, it overwrote SuperFX RAM and could continue past the allocation. `preparesfx` now checks the available ROM region before copying and skips expansion when the result would overlap the reserved SuperFX RAM area.