### PR TITLE
Terminate truncated ZIP filenames

### DIFF
--- a/zip/unzip.c
+++ b/zip/unzip.c
@@ -565,13 +565,17 @@ uLong commentBufferSize;
     lSeek += file_info.size_filename;
     if ((err == UNZ_OK) && (szFileName != NULL)) {
         uLong uSizeRead;
-        if (file_info.size_filename < fileNameBufferSize) {
-            *(szFileName + file_info.size_filename) = '\0';
-            uSizeRead = file_info.size_filename;
-        } else
-            uSizeRead = fileNameBufferSize;
+        if (fileNameBufferSize > 0) {
+            if (file_info.size_filename < fileNameBufferSize)
+                uSizeRead = file_info.size_filename;
+            else
+                uSizeRead = fileNameBufferSize - 1;
+            *(szFileName + uSizeRead) = '\0';
+        } else {
+            uSizeRead = 0;
+        }
 
-        if ((file_info.size_filename > 0) && (fileNameBufferSize > 0))
+        if ((file_info.size_filename > 0) && (uSizeRead > 0))
             if (fread(szFileName, (uInt)uSizeRead, 1, s->file) != 1)
                 err = UNZ_ERRNO;
         lSeek -= uSizeRead;


### PR DESCRIPTION
This fixes an out-of-bounds read when opening crafted ZIP ROMs or applying IPS patches from ZIP files.

`loadZipFile` and `findZipIPS` request a 256-byte filename buffer from `unzGetCurrentFileInfo`. For a ZIP entry whose filename is 256 bytes or longer, `zip/unzip.c` previously copied the full buffer without adding a NUL terminator. The callers then passed the unterminated buffer to `strlen`, `isextension`, and `strcpy`.

The ZIP reader now reserves one byte for the terminator, truncates oversized filenames safely, adjusts its file-position bookkeeping for the truncated read, and handles zero-length destination buffers correctly.