### PR TITLE
Bound combo file record counts

### DIFF
--- a/gui/guifuncs.c
+++ b/gui/guifuncs.c
@@ -549,6 +549,10 @@ void GUIRestoreVars()
 
         if (ComboBlHeader[22]) {
             NumComboGlob = ComboBlHeader[22];
+
+            if (NumComboGlob > lengthof(CombinDataGlob))
+                NumComboGlob = lengthof(CombinDataGlob);
+
             fread(CombinDataGlob, sizeof(*CombinDataGlob), NumComboGlob, cfg_fp);
         }
 

--- a/initc.c
+++ b/initc.c
@@ -1952,6 +1952,9 @@ void OpenCombFile()
         fread(ComboHeader, 1, 23, fp);
         NumComboLocl = ComboHeader[22];
 
+        if (NumComboLocl > lengthof(CombinDataLocl))
+            NumComboLocl = lengthof(CombinDataLocl);
+
         if (NumComboLocl) {
             fread(CombinDataLocl, sizeof(*CombinDataLocl), NumComboLocl, fp);
         }


### PR DESCRIPTION
Combo files store their record count in header byte 22. OpenCombFile() passes that untrusted count directly to fread() even though CombinDataLocl contains only 50 entries. The global data.cmb loader in guifuncs.c has the same mismatch with CombinDataGlob.

A crafted combo file can therefore make fread() overwrite adjacent state during the automatic loading path from loadfileGUI().

Clamp both local and global record counts to their 50-entry destinations before reading the records.