### PR TITLE
Bound legacy cheat record conversion

### DIFF
--- a/gui/guifuncs.c
+++ b/gui/guifuncs.c
@@ -656,17 +656,21 @@ void CheatCodeLoad(void)
             NumCheats = cheat_file_size / 28;
         else {
             NumCheats = cheat_file_size / 18;
-            i = 28 * NumCheats;
-            j = cheat_file_size - (cheat_file_size % 18);
+            if (NumCheats > 255) {
+                NumCheats = 0;
+            } else {
+                i = 28 * NumCheats;
+                j = cheat_file_size - (cheat_file_size % 18);
 
-            do {
-                i -= 28;
-                j -= 18;
+                do {
+                    i -= 28;
+                    j -= 18;
 
-                memset(&cheatdata[i + 20], 0, 8);
-                memmove(&cheatdata[i + 8], &cheatdata[j + 6], 12);
-                memmove(&cheatdata[i], &cheatdata[j], 6);
-            } while (i > 0);
+                    memset(&cheatdata[i + 20], 0, 8);
+                    memmove(&cheatdata[i + 8], &cheatdata[j + 6], 12);
+                    memmove(&cheatdata[i], &cheatdata[j], 6);
+                } while (i > 0);
+            }
         }
 
         EnableCheatsOnLoad();


### PR DESCRIPTION
CheatCodeLoad() reads legacy cheat files as 18-byte records, then expands each record to 28 bytes in cheatdata. The destination is limited to 255 cheats, but the loader derives the legacy record count from the file size without applying that limit.

A crafted legacy cheat file can therefore make the conversion write beyond cheatdata when loaded through AutoLoadCht() in initc.c or manually through the GUI.

Reject legacy files with more than 255 records before conversion so the expanded data remains within cheatdata.